### PR TITLE
Move Vite entry to src/main and fix build transform error

### DIFF
--- a/raikomix-youtube-dj_1.0/App.tsx
+++ b/raikomix-youtube-dj_1.0/App.tsx
@@ -401,7 +401,7 @@ const App: React.FC = () => {
               </div>
             </section>
           ) : (
-            <section className="bg-black/20 border-r border-white/5 flex flex-col h-full w-[420px] shrink-0">
+            <section className="bg-black/20 border-r border-white/5 flex flex-col h-full w-[clamp(320px,25vw,420px)] shrink-0">
               <div className="p-4 flex flex-col gap-4 h-full">
                 <EffectsPanel
                    activeEffect={targetEffect}
@@ -452,8 +452,8 @@ const App: React.FC = () => {
             </section>
           )}
 
-          <section className="flex-1 flex flex-col p-4 items-center justify-center overflow-auto min-h-0">
-            <div className="flex flex-col lg:flex-row gap-6 items-center">
+          <section className="flex-1 flex flex-col items-center justify-center overflow-auto min-h-0 perform-stage">
+            <div className="flex flex-col lg:flex-row items-center perform-stage__inner">
              <Deck ref={deckARef} id="A" color="#D0BCFF" eq={deckAEq} effect={deckAEffect} effectWet={deckAEffectWet} effectIntensity={deckAEffectIntensity} onStateUpdate={s => handleDeckStateUpdate('A', s)} onPlayerReady={p => setMasterPlayerA(p)} onTrackEnd={() => handleTrackEnd('A')} />
             <Mixer
                 crossfader={crossfader}

--- a/raikomix-youtube-dj_1.0/components/Deck.tsx
+++ b/raikomix-youtube-dj_1.0/components/Deck.tsx
@@ -734,7 +734,7 @@ const effectNodesRef = useRef<{
   };
 
   return (
-    <div className="m3-card bg-[#1D1B20] border-white/5 flex flex-col gap-4 shadow-2xl transition-all hover:border-[#D0BCFF]/20 relative overflow-hidden min-w-[420px]">
+    <div className="m3-card deck-card bg-[#1D1B20] border-white/5 flex flex-col gap-4 shadow-2xl transition-all hover:border-[#D0BCFF]/20 relative overflow-hidden">
       <div className="absolute top-0 left-0 w-px h-px opacity-0 pointer-events-none overflow-hidden">
         <div id={containerId} />
       </div>

--- a/raikomix-youtube-dj_1.0/components/Mixer.tsx
+++ b/raikomix-youtube-dj_1.0/components/Mixer.tsx
@@ -260,7 +260,7 @@ const Mixer: React.FC<MixerProps> = ({
   };
 
   return (
-    <div className="m3-card h-full flex flex-col bg-[#1D1B20] shadow-2xl border-white/5 w-[280px] shrink-0 p-2 select-none" role="region" aria-label="Mixer Controls">
+    <div className="m3-card mixer-card h-full flex flex-col bg-[#1D1B20] shadow-2xl border-white/5 shrink-0 p-2 select-none" role="region" aria-label="Mixer Controls">
       <div className="flex flex-col items-center gap-0 border-b border-white/5 pb-1 mb-2">
         <h2 className="text-[8px] font-black uppercase tracking-[0.4em] text-[#D0BCFF]">Mixing Console</h2>
       </div>

--- a/raikomix-youtube-dj_1.0/components/PerformancePads.tsx
+++ b/raikomix-youtube-dj_1.0/components/PerformancePads.tsx
@@ -706,8 +706,8 @@ const PerformancePads: React.FC<PerformancePadsProps> = ({
       onKeyUp={handleKeyUp}
       aria-label="Performance pads"
     >
-      <div className="max-w-md mx-auto">
-        <div className="grid grid-cols-2 gap-4">
+      <div className="max-w-md mx-auto w-full">
+        <div className="grid grid-cols-2 gap-3 lg:gap-4 performance-pads-grid">
           {pads.map((pad) => {
             const isPlaying = playingPads[pad.id];
             const isLoaded = pad.sourceType !== 'empty';
@@ -735,7 +735,7 @@ const PerformancePads: React.FC<PerformancePadsProps> = ({
                   event.preventDefault();
                   setActivePadId(pad.id);
                 }}
-                className={`group relative aspect-square h-32 rounded-lg border-2 bg-black/40 text-left transition-all focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#D0BCFF]/60 focus-visible:ring-inset p-2 ${
+                className={`group relative aspect-square performance-pad rounded-lg border-2 bg-black/40 text-left transition-all focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#D0BCFF]/60 focus-visible:ring-inset p-2 ${
                   isLoaded
                     ? 'border-white/20 hover:border-[#D0BCFF]/40'
                     : 'border-white/10 hover:border-white/20'

--- a/raikomix-youtube-dj_1.0/index.html
+++ b/raikomix-youtube-dj_1.0/index.html
@@ -107,6 +107,41 @@
       border: 1px solid rgba(255, 255, 255, 0.05);
     }
 
+    .perform-stage {
+      padding: clamp(16px, 3vw, 36px);
+    }
+
+    .perform-stage__inner {
+      gap: clamp(16px, 3vw, 32px);
+      flex-wrap: wrap;
+      justify-content: center;
+      max-width: 100%;
+    }
+
+    .deck-card {
+      width: clamp(320px, 34vw, 420px);
+      max-width: 100%;
+    }
+
+    .mixer-card {
+      width: clamp(220px, 18vw, 280px);
+      max-width: 100%;
+    }
+
+    .performance-pad {
+      height: clamp(76px, 11vh, 128px);
+    }
+
+    .performance-pads-grid {
+      justify-items: stretch;
+    }
+
+    @media (min-width: 1280px) {
+      .perform-stage__inner {
+        flex-wrap: nowrap;
+      }
+    }
+
     /* Vertical Text Utility */
     .vertical-text {
       writing-mode: vertical-rl;
@@ -143,6 +178,6 @@
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <div id="root"></div>
-  <script type="module" src="/index.tsx"></script>
+  <script type="module" src="/src/main.tsx"></script>
 </body>
 </html>

--- a/raikomix-youtube-dj_1.0/src/main.tsx
+++ b/raikomix-youtube-dj_1.0/src/main.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App';
+import App from '../App';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/raikomix-youtube-dj_1.0/vercel.json
+++ b/raikomix-youtube-dj_1.0/vercel.json
@@ -1,0 +1,5 @@
+{
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist"
+}


### PR DESCRIPTION
### Motivation
- Fix a failing production build where the Vite HTML -> JS transform errored because the app entry was referenced incorrectly from `index.html`. 
- Ensure the project follows the standard Vite entry layout so build tooling (and Vercel) resolve the module correctly. 

### Description
- Move the app entry module from the repository root into `src/main.tsx` and update the app bootstrap to import `App` from the correct relative path (`../App`) in `src/main.tsx`. 
- Update `index.html` to point its module script to `/src/main.tsx` so Vite resolves the entry as a JS/TS module instead of attempting to parse HTML as code. 
- Keep the existing responsive layout and UI utility changes (deck/mixer/pads class names are in place) while only adjusting the module entry and import paths necessary for a successful build. 

### Testing
- Ran `npm run build` (Vite) and the production build completed successfully and produced `dist/` assets, with a chunk-size warning but an exit code of `0` indicating success. 
- Observed output files such as `dist/index.html`, `dist/assets/index-*.css`, and `dist/assets/index-*.js` present after the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69748be9cbc8832694f579d9fe1204fb)