### PR TITLE
Add precise local waveform rendering with YouTube fallback

### DIFF
--- a/raikomix-youtube-dj_1.0/components/Waveform.tsx
+++ b/raikomix-youtube-dj_1.0/components/Waveform.tsx
@@ -6,12 +6,83 @@ interface WaveformProps {
   volume: number;
   color: string;
   playbackRate: number;
+  currentTime: number;
+  duration: number;
+  peaks?: number[];
+  sourceType?: 'youtube' | 'local';
 }
 
-const Waveform: React.FC<WaveformProps> = ({ isPlaying, volume, color, playbackRate }) => {
+const Waveform: React.FC<WaveformProps> = ({ isPlaying, volume, color, playbackRate, currentTime, duration, peaks, sourceType = 'youtube' }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const requestRef = useRef<number>(null);
   const offsetRef = useRef(0);
+  const sizeRef = useRef({ width: 0, height: 0, dpr: 1 });
+
+  const resizeCanvas = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const { width, height } = canvas.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    const nextWidth = Math.max(1, Math.floor(width * dpr));
+    const nextHeight = Math.max(1, Math.floor(height * dpr));
+    if (canvas.width !== nextWidth || canvas.height !== nextHeight) {
+      canvas.width = nextWidth;
+      canvas.height = nextHeight;
+      sizeRef.current = { width: nextWidth, height: nextHeight, dpr };
+    }
+  };
+
+  const drawPeaks = (ctx: CanvasRenderingContext2D, width: number, height: number, progress: number) => {
+    if (!peaks || peaks.length === 0) return;
+    const centerY = height / 2;
+    const barWidth = width / peaks.length;
+    const baseLineWidth = Math.max(1, barWidth * 0.7);
+
+    ctx.lineCap = 'round';
+    ctx.lineWidth = baseLineWidth;
+    ctx.strokeStyle = `${color}88`;
+    ctx.shadowBlur = 0;
+    ctx.beginPath();
+
+    peaks.forEach((peak, index) => {
+      const x = index * barWidth + barWidth / 2;
+      const amplitude = peak * (height * 0.42);
+      ctx.moveTo(x, centerY - amplitude);
+      ctx.lineTo(x, centerY + amplitude);
+    });
+    ctx.stroke();
+
+    const clampedProgress = Math.min(1, Math.max(0, progress));
+    const progressWidth = clampedProgress * width;
+    if (progressWidth > 0) {
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(0, 0, progressWidth, height);
+      ctx.clip();
+      ctx.strokeStyle = color;
+      ctx.shadowBlur = 12;
+      ctx.shadowColor = color;
+      ctx.beginPath();
+      peaks.forEach((peak, index) => {
+        const x = index * barWidth + barWidth / 2;
+        const amplitude = peak * (height * 0.46);
+        ctx.moveTo(x, centerY - amplitude);
+        ctx.lineTo(x, centerY + amplitude);
+      });
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    ctx.shadowBlur = 12;
+    ctx.shadowColor = color;
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.5;
+    const playheadX = Math.min(width, Math.max(0, progress * width));
+    ctx.beginPath();
+    ctx.moveTo(playheadX, height * 0.1);
+    ctx.lineTo(playheadX, height * 0.9);
+    ctx.stroke();
+  };
 
   const draw = () => {
     const canvas = canvasRef.current;
@@ -19,10 +90,18 @@ const Waveform: React.FC<WaveformProps> = ({ isPlaying, volume, color, playbackR
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
+    resizeCanvas();
     const width = canvas.width;
     const height = canvas.height;
     ctx.clearRect(0, 0, width, height);
-    
+    const progress = duration > 0 ? currentTime / duration : 0;
+
+    if (peaks && peaks.length > 0) {
+      drawPeaks(ctx, width, height, progress);
+      requestRef.current = requestAnimationFrame(draw);
+      return;
+    }
+
     const centerY = height / 2;
     const amplitude = isPlaying ? (height / 3) * (volume / 100) : 2;
     const frequency = 0.015;
@@ -40,7 +119,7 @@ const Waveform: React.FC<WaveformProps> = ({ isPlaying, volume, color, playbackR
     for (let x = 0; x < width; x += 3) {
       const yOffset = Math.sin(x * frequency + offsetRef.current) * amplitude;
       const noise = isPlaying ? (Math.random() - 0.5) * (volume / 5) : 0;
-      
+
       if (x === 0) {
         ctx.moveTo(x, centerY + yOffset + noise);
       } else {
@@ -49,7 +128,6 @@ const Waveform: React.FC<WaveformProps> = ({ isPlaying, volume, color, playbackR
     }
     ctx.stroke();
 
-    // Secondary wave for depth
     ctx.beginPath();
     ctx.lineWidth = 1;
     ctx.strokeStyle = color;
@@ -62,23 +140,31 @@ const Waveform: React.FC<WaveformProps> = ({ isPlaying, volume, color, playbackR
     ctx.stroke();
     ctx.globalAlpha = 1.0;
 
+    if (sourceType === 'youtube') {
+      ctx.strokeStyle = 'rgba(255,255,255,0.15)';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(0, height * 0.5);
+      ctx.lineTo(width, height * 0.5);
+      ctx.stroke();
+    }
+
     requestRef.current = requestAnimationFrame(draw);
   };
 
   useEffect(() => {
+    resizeCanvas();
     requestRef.current = requestAnimationFrame(draw);
     return () => {
       if (requestRef.current) cancelAnimationFrame(requestRef.current);
     };
-  }, [isPlaying, volume, playbackRate, color]);
+  }, [isPlaying, volume, playbackRate, color, peaks, currentTime, duration, sourceType]);
 
   return (
     <div className="w-full h-24 bg-black/60 rounded-lg overflow-hidden border border-white/5 shadow-inner relative">
       <div className="absolute inset-0 bg-gradient-to-b from-transparent via-white/5 to-transparent pointer-events-none" />
       <canvas 
         ref={canvasRef} 
-        width={800} 
-        height={120} 
         className="w-full h-full"
       />
     </div>

--- a/raikomix-youtube-dj_1.0/types.ts
+++ b/raikomix-youtube-dj_1.0/types.ts
@@ -54,6 +54,7 @@ export interface PlayerState {
   loopActive: boolean;
   loopStart: number;
   loopEnd: number;
+  waveformPeaks?: number[];
 }
 
 export interface QueueItem {

--- a/raikomix-youtube-dj_1.0/utils/waveform.ts
+++ b/raikomix-youtube-dj_1.0/utils/waveform.ts
@@ -1,0 +1,43 @@
+export const buildWaveformPeaks = (audioBuffer: AudioBuffer, samples = 900): number[] => {
+  const channels = audioBuffer.numberOfChannels;
+  if (channels === 0) return [];
+
+  const channelData: Float32Array[] = [];
+  for (let i = 0; i < channels; i += 1) {
+    channelData.push(audioBuffer.getChannelData(i));
+  }
+
+  const totalSamples = channelData[0].length;
+  const blockSize = Math.max(1, Math.floor(totalSamples / samples));
+  const peaks: number[] = [];
+
+  for (let i = 0; i < samples; i += 1) {
+    const start = i * blockSize;
+    const end = Math.min(start + blockSize, totalSamples);
+    let peak = 0;
+
+    for (let j = start; j < end; j += 1) {
+      let sample = 0;
+      for (let c = 0; c < channels; c += 1) {
+        sample += channelData[c][j];
+      }
+      sample /= channels;
+      const abs = Math.abs(sample);
+      if (abs > peak) peak = abs;
+    }
+
+    peaks.push(peak);
+  }
+
+  const maxPeak = Math.max(0.00001, ...peaks);
+  const normalized = peaks.map((value) => Math.min(1, value / maxPeak));
+  const smoothed: number[] = [];
+
+  for (let i = 0; i < normalized.length; i += 1) {
+    const prev = normalized[i - 1] ?? normalized[i];
+    const next = normalized[i + 1] ?? normalized[i];
+    smoothed.push((prev + normalized[i] + next) / 3);
+  }
+
+  return smoothed;
+};


### PR DESCRIPTION
### Motivation
- Provide an accurate, in-sync waveform visualization for local audio files while preserving the animated fallback for YouTube streams.
- Improve UX for beat/tempo workflows by generating waveform peaks from decoded audio so timeline and playhead visuals align with the actual audio.

### Description
- Add an optional `waveformPeaks?: number[]` field to `PlayerState` in `types.ts` to store precomputed waveform data.
- Add `utils/waveform.ts` with `buildWaveformPeaks(audioBuffer, samples)` to compute normalized, smoothed peak arrays from a decoded `AudioBuffer`.
- Update `components/Deck.tsx` to decode local audio in `analyzeLocalAudio`, detect BPM, compute `waveformPeaks`, and store them in deck state, and pass `currentTime`, `duration`, `peaks`, and `sourceType` into the `Waveform` component.
- Enhance `components/Waveform.tsx` to support DPR-aware canvas resizing, draw precise peak bars with a colored progress overlay and playhead when `peaks` are present, and keep the animated waveform fallback for non-local (YouTube) sources.

### Testing
- Built and served the app with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready (local and network URLs), indicating the dev build succeeded.
- Ran a Playwright smoke script that loaded `http://127.0.0.1:4173/` and captured a screenshot (`artifacts/waveform-update.png`), which completed successfully. 
- No unit tests were added or run for this UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975fe5646748326ab10437fc0a4c312)