### PR TITLE
Align mix setting number input styling

### DIFF
--- a/raikomix-youtube-dj_1.0/components/Mixer.tsx
+++ b/raikomix-youtube-dj_1.0/components/Mixer.tsx
@@ -437,7 +437,7 @@ const Mixer: React.FC<MixerProps> = ({
               max={30}
               value={mixLeadSeconds}
               onChange={(e) => onMixLeadChange(Number(e.target.value))}
-              className="w-full rounded-md bg-black/40 border border-white/10 px-2 py-1 text-[9px] text-white"
+              className="mix-number-input w-full rounded-md bg-black/40 border border-white/10 px-2 py-1 text-[9px] text-white"
             />
           </label>
           <label className="flex flex-col gap-1">
@@ -448,7 +448,7 @@ const Mixer: React.FC<MixerProps> = ({
               max={20}
               value={mixDurationSeconds}
               onChange={(e) => onMixDurationChange(Number(e.target.value))}
-              className="w-full rounded-md bg-black/40 border border-white/10 px-2 py-1 text-[9px] text-white"
+              className="mix-number-input w-full rounded-md bg-black/40 border border-white/10 px-2 py-1 text-[9px] text-white"
             />
           </label>
         </div>

--- a/raikomix-youtube-dj_1.0/components/QueuePanel.tsx
+++ b/raikomix-youtube-dj_1.0/components/QueuePanel.tsx
@@ -101,7 +101,7 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
               max={30}
               value={mixLeadSeconds}
               onChange={(e) => onMixLeadChange(Number(e.target.value))}
-              className="w-full rounded-md bg-black/40 border border-white/10 px-2 py-1 text-[10px] text-white"
+              className="mix-number-input w-full rounded-md bg-black/40 border border-white/10 px-2 py-1 text-[10px] text-white"
             />
           </label>
           <label className="flex flex-col gap-1">
@@ -112,7 +112,7 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
               max={20}
               value={mixDurationSeconds}
               onChange={(e) => onMixDurationChange(Number(e.target.value))}
-              className="w-full rounded-md bg-black/40 border border-white/10 px-2 py-1 text-[10px] text-white"
+              className="mix-number-input w-full rounded-md bg-black/40 border border-white/10 px-2 py-1 text-[10px] text-white"
             />
           </label>
         </div>

--- a/raikomix-youtube-dj_1.0/index.html
+++ b/raikomix-youtube-dj_1.0/index.html
@@ -154,6 +154,16 @@
       font-variation-settings: 'FILL' 1;
     }
 
+    .mix-number-input {
+      appearance: textfield;
+    }
+
+    .mix-number-input::-webkit-outer-spin-button,
+    .mix-number-input::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+
     .m3-card {
       background: var(--md-sys-color-surface-container);
       border-radius: 16px;


### PR DESCRIPTION
### Motivation
- Make the Mix Lead and Mix Duration numeric controls match the app UX by removing the native browser spinner UI so the inputs align visually with other controls.

### Description
- Add a `.mix-number-input` CSS rule (in `index.html`) that removes native spinner controls and apply the class to the Mix Lead/Duration `input[type=number]` fields in `components/Mixer.tsx` and `components/QueuePanel.tsx`.

### Testing
- Started the dev server with `npm run dev` (Vite started and served at `http://localhost:4173/`) and captured a screenshot using a Playwright script which completed successfully, confirming the updated input styling rendered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697626b758708326a747ddf7ab84a3e5)