### PR TITLE
Add queue reordering with drag-and-drop and move buttons

### DIFF
--- a/raikomix-youtube-dj_1.0/App.tsx
+++ b/raikomix-youtube-dj_1.0/App.tsx
@@ -207,6 +207,18 @@ const App: React.FC = () => {
     showNotification('Added to Queue');
   }, []);
 
+  const handleQueueReorder = useCallback((from: number, to: number) => {
+    setQueue(prev => {
+      if (from === to || from < 0 || to < 0 || from >= prev.length || to >= prev.length) {
+        return prev;
+      }
+      const next = [...prev];
+      const [moved] = next.splice(from, 1);
+      next.splice(to, 0, moved);
+      return next;
+    });
+  }, []);
+
   const stopDeck = useCallback((deckId: DeckId) => {
     const state = deckId === 'A' ? deckAState : deckBState;
     const ref = deckId === 'A' ? deckARef : deckBRef;
@@ -667,7 +679,7 @@ useEffect(() => {
                     onLoadToDeck={(i, d) => { handleLoadVideo(i.videoId, i.url, d, i.sourceType || 'youtube', i.title, i.author); setQueue(p => p.filter(q => q.id !== i.id)); }} 
                     onRemove={id => setQueue(p => p.filter(i => i.id !== id))} 
                     onClear={() => setQueue([])} 
-                    onReorder={() => {}} 
+                    onReorder={handleQueueReorder} 
                   />
                 </div>
               </aside>

--- a/raikomix-youtube-dj_1.0/components/QueuePanel.tsx
+++ b/raikomix-youtube-dj_1.0/components/QueuePanel.tsx
@@ -50,8 +50,35 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
   onMixDurationChange,
   onLoadToDeck,
   onRemove,
-  onClear
+  onClear,
+  onReorder
 }) => {
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
+
+  const handleDragStart = (index: number) => {
+    setDragIndex(index);
+  };
+
+  const handleDragEnd = () => {
+    setDragIndex(null);
+    setOverIndex(null);
+  };
+
+  const handleDrop = (index: number) => {
+    if (dragIndex === null || dragIndex === index) {
+      handleDragEnd();
+      return;
+    }
+    onReorder(dragIndex, index);
+    handleDragEnd();
+  };
+
+  const handleMove = (from: number, to: number) => {
+    if (to < 0 || to >= queue.length) return;
+    onReorder(from, to);
+  };
+
   return (
     <div className="flex flex-col h-full gap-4 elevation-2">
       <div className="flex items-center justify-between px-2">
@@ -74,6 +101,11 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
           </div>
         )}
       </div>
+      {queue.length > 1 && (
+        <div className="px-2 text-[9px] uppercase tracking-[0.3em] text-gray-600">
+          Drag to reorder
+        </div>
+      )}
 
       <div className="rounded-xl border border-white/5 bg-black/30 p-3 space-y-3">
         <div className="flex items-center justify-between">
@@ -127,8 +159,28 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
         )}
 
         {queue.map((item, index) => (
-          <div key={item.id} className="m3-card group p-3 flex gap-4 items-center bg-[#1C1B1F]/40 hover:bg-[#2B2930] motion-standard border-dashed elevation-1 hover:elevation-2 overflow-hidden">
+          <div
+            key={item.id}
+            className={`m3-card group p-3 flex gap-4 items-center bg-[#1C1B1F]/40 hover:bg-[#2B2930] motion-standard border-dashed elevation-1 hover:elevation-2 overflow-hidden ${
+              overIndex === index ? 'ring-1 ring-[#D0BCFF]/40' : ''
+            }`}
+            draggable
+            onDragStart={(event) => {
+              event.dataTransfer.effectAllowed = 'move';
+              handleDragStart(index);
+            }}
+            onDragEnd={handleDragEnd}
+            onDragOver={(event) => {
+              event.preventDefault();
+              if (overIndex !== index) setOverIndex(index);
+            }}
+            onDragLeave={() => {
+              if (overIndex === index) setOverIndex(null);
+            }}
+            onDrop={() => handleDrop(index)}
+          >
             <span className="text-[10px] font-mono text-gray-600 w-4">{index + 1}</span>
+            <span className="material-symbols-outlined text-gray-600 text-sm cursor-grab">drag_indicator</span>
             <div className="w-12 h-12 bg-black rounded overflow-hidden flex-shrink-0 elevation-1">
               <img src={item.thumbnailUrl} alt={item.title} className="w-full h-full object-cover" />
             </div>
@@ -161,6 +213,22 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
               >
                 <span className="material-symbols-outlined text-lg">close</span>
               </button>
+              <div className="flex flex-col">
+                <button
+                  onClick={() => handleMove(index, index - 1)}
+                  className="w-6 h-4 flex items-center justify-center text-gray-500 hover:text-white"
+                  title="Move up"
+                >
+                  <span className="material-symbols-outlined text-sm">keyboard_arrow_up</span>
+                </button>
+                <button
+                  onClick={() => handleMove(index, index + 1)}
+                  className="w-6 h-4 flex items-center justify-center text-gray-500 hover:text-white"
+                  title="Move down"
+                >
+                  <span className="material-symbols-outlined text-sm">keyboard_arrow_down</span>
+                </button>
+              </div>
             </div>
           </div>
         ))}


### PR DESCRIPTION
### Motivation
- Provide users a way to change the play order of queued songs to match the app UX expectations. 
- Make ordering quick and discoverable by adding inline drag-and-drop plus precise move up/down controls. 

### Description
- Added a new `handleQueueReorder` callback in `App.tsx` to update the `queue` order in state. 
- Wired `onReorder` into `QueuePanel` and implemented drag-and-drop behavior and visual feedback in `components/QueuePanel.tsx` using `dragstart`/`dragover`/`drop` handlers. 
- Added small UI affordances including a `drag_indicator` icon, a `Drag to reorder` hint, highlight ring on drop target, and up/down buttons for precise reordering. 
- Implemented defensive checks for invalid indices and preserved existing load/remove/clear behaviors while keeping styles consistent with the app. 

### Testing
- Started the dev server with `npm run dev` (Vite reported ready) and the server started successfully. 
- Automated UI smoke check: opened the app in headless Playwright and captured a screenshot saved as `artifacts/queue-reorder.png`, which completed successfully. 
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69764939f99083268fc5c5d975e98ea1)