### PR TITLE
Animate queue artist ticker and wire up queue reorder UI

### DIFF
--- a/raikomix-youtube-dj_1.0/App.tsx
+++ b/raikomix-youtube-dj_1.0/App.tsx
@@ -207,6 +207,18 @@ const App: React.FC = () => {
     showNotification('Added to Queue');
   }, []);
 
+  const handleQueueReorder = useCallback((from: number, to: number) => {
+    setQueue(prev => {
+      if (from === to || from < 0 || to < 0 || from >= prev.length || to >= prev.length) {
+        return prev;
+      }
+      const next = [...prev];
+      const [moved] = next.splice(from, 1);
+      next.splice(to, 0, moved);
+      return next;
+    });
+  }, []);
+
   const stopDeck = useCallback((deckId: DeckId) => {
     const state = deckId === 'A' ? deckAState : deckBState;
     const ref = deckId === 'A' ? deckARef : deckBRef;
@@ -667,7 +679,7 @@ useEffect(() => {
                     onLoadToDeck={(i, d) => { handleLoadVideo(i.videoId, i.url, d, i.sourceType || 'youtube', i.title, i.author); setQueue(p => p.filter(q => q.id !== i.id)); }} 
                     onRemove={id => setQueue(p => p.filter(i => i.id !== id))} 
                     onClear={() => setQueue([])} 
-                    onReorder={() => {}} 
+                    onReorder={handleQueueReorder} 
                   />
                 </div>
               </aside>


### PR DESCRIPTION
### Motivation
- Surface artist/creator names in the queue in a compact, readable way by adding a subtle always-on ticker for long names so they remain visible in the current UI layout.
- Wire the queue reorder UI into app state and improve discoverability and precision by enabling drag-and-drop reordering plus up/down controls.

### Description
- Added a `forceAnimate` flag to the `MarqueeText` helper in `components/QueuePanel.tsx` and applied it to the queue item artist line so the artist text always scrolls when needed and matches the queue microcopy style (`uppercase tracking-[0.2em]`).
- Enhanced `QueuePanel.tsx` with drag-and-drop support and visual feedback by making queue items `draggable`, tracking `dragIndex`/`overIndex`, adding `onDragStart`/`onDragOver`/`onDrop`/`onDragEnd` handlers and a highlight ring for the current drop target.
- Added precise move controls (move up/down buttons) to the queue item actions for keyboard/precise reordering.
- Wired the UI into application state by adding `handleQueueReorder` in `App.tsx` and passing it as `onReorder` into `QueuePanel`, implementing safe index checks and immutable reordering.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready on `http://localhost:4173/`, which succeeded.
- Ran a headless Playwright script that loaded the app and saved a screenshot to `artifacts/queue-artist-marquee.png`, which completed successfully.
- No unit tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69764939f99083268fc5c5d975e98ea1)