### PR TITLE
Show artist name in queue with scrolling marquee chip

### DIFF
--- a/raikomix-youtube-dj_1.0/components/QueuePanel.tsx
+++ b/raikomix-youtube-dj_1.0/components/QueuePanel.tsx
@@ -184,16 +184,18 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
             <div className="w-12 h-12 bg-black rounded overflow-hidden flex-shrink-0 elevation-1">
               <img src={item.thumbnailUrl} alt={item.title} className="w-full h-full object-cover" />
             </div>
-            <div className="flex-1 min-w-0 flex flex-col gap-1 overflow-hidden">
+            <div className="flex-1 min-w-0 flex flex-col gap-2 overflow-hidden">
               <MarqueeText 
                 text={item.title} 
                 className="text-sm font-semibold text-[#E6E1E5] leading-tight" 
               />
-              <MarqueeText 
-                text={item.author || 'Unknown Artist'} 
-                className="text-[10px] text-gray-400 font-medium uppercase tracking-[0.2em]" 
-                forceAnimate
-              />
+              <div className="rounded-full border border-white/5 bg-black/40 px-2 py-0.5">
+                <MarqueeText 
+                  text={item.author || 'Unknown Artist'} 
+                  className="text-[9px] text-gray-300 font-semibold uppercase tracking-[0.2em]" 
+                  forceAnimate
+                />
+              </div>
             </div>
             <div className="flex gap-1 opacity-0 group-hover:opacity-100 motion-standard">
               <button 


### PR DESCRIPTION
### Motivation
- Surface the missing song/artist metadata in the queue by adding a small, readable UI element that matches the existing card styling and uses the same marquee behavior when text overflows.

### Description
- Update `components/QueuePanel.tsx` to render the artist/author underneath the track title inside a rounded, high-contrast pill and reuse the existing `MarqueeText` component so long names scroll when needed.

### Testing
- Launched the dev server with `npm run dev` (Vite ready) and ran a Playwright script to capture a screenshot of the updated queue UI (`artifacts/queue-marquee.png`), both actions completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69764c2218b8832688d9048cf05ca765)