### PR TITLE
Update queue card styling and metadata tooltip

### DIFF
--- a/raikomix-youtube-dj_1.0/App.tsx
+++ b/raikomix-youtube-dj_1.0/App.tsx
@@ -201,6 +201,8 @@ const App: React.FC = () => {
       thumbnailUrl: track.thumbnailUrl,
       addedAt: Date.now(),
       author: 'addedAt' in track ? track.author : (track as YouTubeSearchResult).channelTitle,
+      album: 'addedAt' in track ? track.album : undefined,
+      fileName: 'addedAt' in track ? track.fileName : undefined,
       sourceType: 'sourceType' in track ? track.sourceType : 'youtube'
     };
     setQueue(prev => [...prev, item]);

--- a/raikomix-youtube-dj_1.0/components/QueuePanel.tsx
+++ b/raikomix-youtube-dj_1.0/components/QueuePanel.tsx
@@ -159,7 +159,6 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
         )}
 
         {queue.map((item, index) => {
-          const addedDate = new Date(item.addedAt).toLocaleDateString();
           return (
           <div
             key={item.id}
@@ -190,18 +189,16 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
                 forceAnimate
               />
             </div>
-            <div className="flex-1 min-w-0 flex flex-col gap-2 overflow-hidden">
+            <div className="flex-1 min-w-0 flex flex-col gap-1 overflow-hidden">
               <MarqueeText 
                 text={item.title} 
-                className="text-sm font-semibold text-[#E6E1E5] leading-tight" 
+                className="text-[11px] font-bold text-white leading-tight group-hover:text-[#D0BCFF] transition-colors" 
               />
-              <div className="rounded-full border border-white/5 bg-black/40 px-2 py-0.5">
-                <MarqueeText 
-                  text={item.author || 'Unknown Artist'} 
-                  className="text-[9px] text-gray-300 font-semibold uppercase tracking-[0.2em]" 
-                  forceAnimate
-                />
-              </div>
+              <MarqueeText 
+                text={item.author || 'Unknown Artist'} 
+                className="text-[9px] text-gray-500 uppercase font-bold tracking-tighter" 
+                forceAnimate
+              />
             </div>
             <div className="flex gap-1 opacity-0 group-hover:opacity-100 motion-standard">
               <button 
@@ -244,8 +241,8 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
               <div className="space-y-1 text-gray-200">
                 <div><span className="text-gray-500">Title:</span> {item.title || 'Unknown Title'}</div>
                 <div><span className="text-gray-500">Artist:</span> {item.author || 'Unknown Artist'}</div>
-                <div><span className="text-gray-500">Source:</span> {item.sourceType || 'youtube'}</div>
-                <div><span className="text-gray-500">Added:</span> {addedDate}</div>
+                <div><span className="text-gray-500">Album:</span> {item.album || 'Unknown Album'}</div>
+                <div><span className="text-gray-500">File:</span> {item.fileName || 'N/A'}</div>
               </div>
             </div>
           </div>

--- a/raikomix-youtube-dj_1.0/types.ts
+++ b/raikomix-youtube-dj_1.0/types.ts
@@ -65,6 +65,8 @@ export interface QueueItem {
   thumbnailUrl: string;
   addedAt: number;
   author?: string;
+  album?: string;
+  fileName?: string;
   sourceType?: TrackSourceType;
 }
 


### PR DESCRIPTION
### Motivation
- Make queue song cards visually match the library cards for consistent typography while preserving existing queue behavior. 
- Surface the same rich metadata (title, artist, album, file) on queue items via a hover tooltip so users can inspect tracks like in the library. 

### Description
- Extended `QueueItem` type to include optional `album` and `fileName` fields in `types.ts` so queue items can carry library metadata. 
- Preserve and pass `album` and `fileName` when adding library/search results to the queue in `App.tsx`. 
- Updated `QueuePanel.tsx` layout and styles to align title and artist typography with the library card styles and replaced the compact author pill with an inline author line. 
- Reworked the queue hover tooltip to display `Title`, `Artist`, `Album`, and `File` (matching the library details popover). 

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, and Vite reported ready indicating the app served successfully. 
- Performed a visual smoke test by taking a browser screenshot via Playwright which produced `artifacts/queue-card-style.png` to verify the updated card appearance and tooltip rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697653074e148326a8abd75a31ce2af7)