### PR TITLE
Fix Queue Console header clipping and reflow queue card layout

### DIFF
--- a/raikomix-youtube-dj_1.0/App.tsx
+++ b/raikomix-youtube-dj_1.0/App.tsx
@@ -664,11 +664,13 @@ useEffect(() => {
 
              {viewMode === 'LIBRARY' && (
             <>
-              <aside className={`bg-black/10 flex-none border-l border-white/5 flex flex-col transition-all duration-300 overflow-hidden ${queueOpen ? 'w-80 p-4' : 'w-0 p-0 border-none'}`}>
+              <aside className={`bg-black/10 flex-none border-l border-white/5 flex flex-col transition-all duration-300 overflow-x-hidden ${queueOpen ? 'w-80 p-4' : 'w-0 p-0 border-none'}`}>
                 <div className={`h-full min-w-[280px] ${!queueOpen ? 'opacity-0 invisible' : 'opacity-100 visible transition-opacity'}`}>
-                  <div className="flex items-center justify-between mb-4 border-b border-white/5 pb-2">
+                  <div className="flex items-center justify-between mb-4 border-b border-white/5 pb-2 pr-1">
                     <span className="text-[10px] font-black uppercase text-gray-500 tracking-[0.2em]">Queue Console</span>
-                    <button onClick={() => setQueueOpen(false)} className="text-gray-500 hover:text-white"><span className="material-symbols-outlined text-sm">close</span></button>
+                    <button onClick={() => setQueueOpen(false)} className="flex h-8 w-8 items-center justify-center rounded-md text-gray-500 hover:text-white hover:bg-white/5">
+                      <span className="material-symbols-outlined text-sm leading-none">close</span>
+                    </button>
                   </div>
                   <QueuePanel 
                     queue={queue} 

--- a/raikomix-youtube-dj_1.0/components/QueuePanel.tsx
+++ b/raikomix-youtube-dj_1.0/components/QueuePanel.tsx
@@ -163,7 +163,7 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
           return (
           <div
             key={item.id}
-            className={`m3-card group p-3 flex gap-4 items-center bg-[#1C1B1F]/40 hover:bg-[#2B2930] motion-standard border-dashed elevation-1 hover:elevation-2 overflow-hidden relative ${
+            className={`m3-card group p-3 grid gap-2 bg-[#1C1B1F]/40 hover:bg-[#2B2930] motion-standard border-dashed elevation-1 hover:elevation-2 relative ${
               overIndex === index ? 'ring-1 ring-[#D0BCFF]/40' : ''
             }`}
             draggable
@@ -181,55 +181,63 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
             }}
             onDrop={() => handleDrop(index)}
           >
-            <span className="text-[10px] font-mono text-gray-600 w-4">{index + 1}</span>
-            <span className="material-symbols-outlined text-gray-600 text-sm cursor-grab">drag_indicator</span>
-            <div className="w-28 h-12 rounded-lg border border-white/10 bg-black/50 px-2 py-1 flex items-center overflow-hidden flex-shrink-0 elevation-1">
-              <MarqueeText
-                text={item.title}
-                className="text-[9px] text-gray-200 font-semibold uppercase tracking-[0.2em]"
-                forceAnimate
-              />
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="flex items-center gap-2 flex-shrink-0">
+                <span className="text-[10px] font-mono text-gray-600 w-4">{index + 1}</span>
+                <span className="material-symbols-outlined text-gray-600 text-sm cursor-grab">drag_indicator</span>
+              </div>
+              <div className="w-28 h-12 rounded-lg border border-white/10 bg-black/50 px-2 py-1 flex items-center overflow-hidden flex-shrink-0 elevation-1">
+                <MarqueeText
+                  text={item.title}
+                  className="text-[9px] text-gray-200 font-semibold uppercase tracking-[0.2em]"
+                  forceAnimate
+                />
+              </div>
+              <div className="flex-1 min-w-[140px]">
+                <MarqueeText
+                  text={item.title}
+                  className="text-sm font-semibold text-[#E6E1E5] leading-tight"
+                />
+              </div>
             </div>
-            <div className="flex-1 min-w-0">
-              <MarqueeText 
-                text={item.title} 
-                className="text-sm font-semibold text-[#E6E1E5] leading-tight" 
-              />
-            </div>
-            <div className="flex gap-1 opacity-0 group-hover:opacity-100 motion-standard">
-              <button 
-                onClick={() => onLoadToDeck(item, 'A')}
-                className="px-2 py-1 rounded bg-[#D0BCFF]/10 text-[#D0BCFF] text-[10px] font-black motion-emphasized elevation-1 hover:elevation-2"
-              >
-                A
-              </button>
-              <button 
-                onClick={() => onLoadToDeck(item, 'B')}
-                className="px-2 py-1 rounded bg-[#F2B8B5]/10 text-[#F2B8B5] text-[10px] font-black motion-emphasized elevation-1 hover:elevation-2"
-              >
-                B
-              </button>
-              <button 
-                onClick={() => onRemove(item.id)}
-                className="w-8 h-8 rounded-full flex items-center justify-center text-gray-500 hover:text-red-400 motion-standard"
-              >
-                <span className="material-symbols-outlined text-lg">close</span>
-              </button>
-              <div className="flex flex-col">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="flex flex-wrap gap-1">
                 <button
-                  onClick={() => handleMove(index, index - 1)}
-                  className="w-6 h-4 flex items-center justify-center text-gray-500 hover:text-white"
-                  title="Move up"
+                  onClick={() => onLoadToDeck(item, 'A')}
+                  className="px-2 py-1 rounded bg-[#D0BCFF]/10 text-[#D0BCFF] text-[10px] font-black motion-emphasized elevation-1 hover:elevation-2"
                 >
-                  <span className="material-symbols-outlined text-sm">keyboard_arrow_up</span>
+                  A
                 </button>
                 <button
-                  onClick={() => handleMove(index, index + 1)}
-                  className="w-6 h-4 flex items-center justify-center text-gray-500 hover:text-white"
-                  title="Move down"
+                  onClick={() => onLoadToDeck(item, 'B')}
+                  className="px-2 py-1 rounded bg-[#F2B8B5]/10 text-[#F2B8B5] text-[10px] font-black motion-emphasized elevation-1 hover:elevation-2"
                 >
-                  <span className="material-symbols-outlined text-sm">keyboard_arrow_down</span>
+                  B
                 </button>
+              </div>
+              <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 motion-standard">
+                <button
+                  onClick={() => onRemove(item.id)}
+                  className="w-8 h-8 rounded-full flex items-center justify-center text-gray-500 hover:text-red-400 motion-standard"
+                >
+                  <span className="material-symbols-outlined text-lg">close</span>
+                </button>
+                <div className="flex flex-col">
+                  <button
+                    onClick={() => handleMove(index, index - 1)}
+                    className="w-6 h-4 flex items-center justify-center text-gray-500 hover:text-white"
+                    title="Move up"
+                  >
+                    <span className="material-symbols-outlined text-sm">keyboard_arrow_up</span>
+                  </button>
+                  <button
+                    onClick={() => handleMove(index, index + 1)}
+                    className="w-6 h-4 flex items-center justify-center text-gray-500 hover:text-white"
+                    title="Move down"
+                  >
+                    <span className="material-symbols-outlined text-sm">keyboard_arrow_down</span>
+                  </button>
+                </div>
               </div>
             </div>
             <div className="pointer-events-none absolute left-12 top-full z-10 mt-2 w-64 rounded-xl border border-white/10 bg-black/90 p-3 text-[9px] text-white opacity-0 shadow-xl transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">


### PR DESCRIPTION
### Motivation
- The Queue Console close button was getting clipped and some queue item controls/text overflowed at narrow sidebar widths due to restrictive header spacing and overflow rules.
- UI-only layout fixes are needed so all controls (drag handle, title, deck buttons) remain visible and clickable without touching any handlers or logic.

### Description
- Adjusted the sidebar container to avoid horizontal clipping by replacing `overflow-hidden` with `overflow-x-hidden` on the queue `aside` and added header right padding via `pr-1` in `App.tsx`.
- Restyled the Queue Console close button to a fixed-size clickable target with `className="flex h-8 w-8 items-center justify-center rounded-md ..."` so the `close` icon is always fully visible in `App.tsx`.
- Reworked the queue item card layout in `components/QueuePanel.tsx` from a single horizontal `flex` row to a responsive `grid` with `flex-wrap` rows, explicit `min-w-[140px]` for the title area, and moved deck buttons into a wrapped row so all controls can wrap instead of overflowing or being clipped.
- Removed the previous overflow-hidden constraint on the card and ensured hover-only controls still appear via `opacity` transitions so no behavior or handlers were changed.

### Testing
- Started the dev server with `npm run dev` and the server became available at `http://localhost:4173/`; this step succeeded.
- Launched an automated Playwright script that navigated to `http://127.0.0.1:4173/` and captured a screenshot (`artifacts/queue-console.png`) to validate the sidebar and queue card rendering; the script completed successfully and produced the screenshot.
- No unit tests were changed or required since this is a layout-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697668faf91c8326af7b58a285ba8148)