### PR TITLE
Compact queue item cards for faster scanning

### DIFF
--- a/raikomix-youtube-dj_1.0/components/QueuePanel.tsx
+++ b/raikomix-youtube-dj_1.0/components/QueuePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { QueueItem, DeckId } from '../types';
 import { exportQueue } from '../utils/queueStorage';
 
@@ -15,30 +15,6 @@ interface QueuePanelProps {
   onClear: () => void;
   onReorder: (from: number, to: number) => void;
 }
-
-const MarqueeText: React.FC<{ text: string; className: string; forceAnimate?: boolean }> = ({ text, className, forceAnimate = false }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const textRef = useRef<HTMLDivElement>(null);
-  const [shouldAnimate, setShouldAnimate] = useState(false);
-
-  useEffect(() => {
-    if (containerRef.current && textRef.current) {
-      setShouldAnimate(forceAnimate || textRef.current.scrollWidth > containerRef.current.clientWidth);
-    }
-  }, [forceAnimate, text]);
-
-  return (
-    <div ref={containerRef} className="marquee-container w-full">
-      <div 
-        ref={textRef} 
-        className={`${className} marquee-text ${shouldAnimate ? 'animate-marquee' : ''}`}
-      >
-        {text}
-        {shouldAnimate && <span className="ml-12">{text}</span>}
-      </div>
-    </div>
-  );
-};
 
 const QueuePanel: React.FC<QueuePanelProps> = ({
   queue,
@@ -72,11 +48,6 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
     }
     onReorder(dragIndex, index);
     handleDragEnd();
-  };
-
-  const handleMove = (from: number, to: number) => {
-    if (to < 0 || to >= queue.length) return;
-    onReorder(from, to);
   };
 
   return (
@@ -158,12 +129,10 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
           </div>
         )}
 
-        {queue.map((item, index) => {
-          const addedDate = new Date(item.addedAt).toLocaleDateString();
-          return (
+        {queue.map((item, index) => (
           <div
             key={item.id}
-            className={`m3-card group p-3 grid gap-2 bg-[#1C1B1F]/40 hover:bg-[#2B2930] motion-standard border-dashed elevation-1 hover:elevation-2 relative ${
+            className={`m3-card group px-2 py-1.5 grid grid-cols-[auto_1fr_auto] items-center gap-2 bg-[#1C1B1F]/40 hover:bg-[#2B2930] motion-standard border-dashed elevation-1 hover:elevation-2 ${
               overIndex === index ? 'ring-1 ring-[#D0BCFF]/40' : ''
             }`}
             draggable
@@ -181,77 +150,31 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
             }}
             onDrop={() => handleDrop(index)}
           >
-            <div className="flex flex-wrap items-center gap-3">
-              <div className="flex items-center gap-2 flex-shrink-0">
-                <span className="text-[10px] font-mono text-gray-600 w-4">{index + 1}</span>
-                <span className="material-symbols-outlined text-gray-600 text-sm cursor-grab">drag_indicator</span>
-              </div>
-              <div className="w-28 h-12 rounded-lg border border-white/10 bg-black/50 px-2 py-1 flex items-center overflow-hidden flex-shrink-0 elevation-1">
-                <MarqueeText
-                  text={item.title}
-                  className="text-[9px] text-gray-200 font-semibold uppercase tracking-[0.2em]"
-                  forceAnimate
-                />
-              </div>
-              <div className="flex-1 min-w-[140px]">
-                <MarqueeText
-                  text={item.title}
-                  className="text-sm font-semibold text-[#E6E1E5] leading-tight"
-                />
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <span className="text-[9px] font-mono text-gray-500 w-4 text-right">{index + 1}</span>
+              <span className="material-symbols-outlined text-gray-600 text-sm cursor-grab">drag_indicator</span>
+            </div>
+            <div className="min-w-0">
+              <div className="text-[11px] font-semibold text-[#E6E1E5] truncate">
+                {item.title}
               </div>
             </div>
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="flex flex-wrap gap-1">
-                <button
-                  onClick={() => onLoadToDeck(item, 'A')}
-                  className="px-2 py-1 rounded bg-[#D0BCFF]/10 text-[#D0BCFF] text-[10px] font-black motion-emphasized elevation-1 hover:elevation-2"
-                >
-                  A
-                </button>
-                <button
-                  onClick={() => onLoadToDeck(item, 'B')}
-                  className="px-2 py-1 rounded bg-[#F2B8B5]/10 text-[#F2B8B5] text-[10px] font-black motion-emphasized elevation-1 hover:elevation-2"
-                >
-                  B
-                </button>
-              </div>
-              <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 motion-standard">
-                <button
-                  onClick={() => onRemove(item.id)}
-                  className="w-8 h-8 rounded-full flex items-center justify-center text-gray-500 hover:text-red-400 motion-standard"
-                >
-                  <span className="material-symbols-outlined text-lg">close</span>
-                </button>
-                <div className="flex flex-col">
-                  <button
-                    onClick={() => handleMove(index, index - 1)}
-                    className="w-6 h-4 flex items-center justify-center text-gray-500 hover:text-white"
-                    title="Move up"
-                  >
-                    <span className="material-symbols-outlined text-sm">keyboard_arrow_up</span>
-                  </button>
-                  <button
-                    onClick={() => handleMove(index, index + 1)}
-                    className="w-6 h-4 flex items-center justify-center text-gray-500 hover:text-white"
-                    title="Move down"
-                  >
-                    <span className="material-symbols-outlined text-sm">keyboard_arrow_down</span>
-                  </button>
-                </div>
-              </div>
-            </div>
-            <div className="pointer-events-none absolute left-12 top-full z-10 mt-2 w-64 rounded-xl border border-white/10 bg-black/90 p-3 text-[9px] text-white opacity-0 shadow-xl transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
-              <div className="font-bold text-[#D0BCFF] mb-1">Track Details</div>
-              <div className="space-y-1 text-gray-200">
-                <div><span className="text-gray-500">Title:</span> {item.title || 'Unknown Title'}</div>
-                <div><span className="text-gray-500">Artist:</span> {item.author || 'Unknown Artist'}</div>
-                <div><span className="text-gray-500">Source:</span> {item.sourceType || 'youtube'}</div>
-                <div><span className="text-gray-500">Added:</span> {addedDate}</div>
-              </div>
+            <div className="flex items-center gap-1 flex-shrink-0">
+              <button
+                onClick={() => onLoadToDeck(item, 'A')}
+                className="px-2 py-1 rounded bg-[#D0BCFF]/10 text-[#D0BCFF] text-[10px] font-black motion-emphasized elevation-1 hover:elevation-2"
+              >
+                A
+              </button>
+              <button
+                onClick={() => onLoadToDeck(item, 'B')}
+                className="px-2 py-1 rounded bg-[#F2B8B5]/10 text-[#F2B8B5] text-[10px] font-black motion-emphasized elevation-1 hover:elevation-2"
+              >
+                B
+              </button>
             </div>
           </div>
-          );
-        })}
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Queue list needed to be denser and scannable so DJs can see more songs at a glance. 
- The song title was duplicated and the card had extra details that are not necessary for quick operation. 
- Keep only the essentials visible (drag handle, index, title, deck A/B) and avoid layout that pushes buttons off-screen.

### Description
- Replace the multi-row Queue item markup with a single-row grid (`grid-cols-[auto_1fr_auto]`) in `components/QueuePanel.tsx` and tighten spacing to `px-2 py-1.5` and smaller typography (`text-[11px]`, `text-[9px]`).
- Remove the duplicated title displays and the hover details tooltip, and use a single truncated title in a `min-w-0` container with `truncate` so it never pushes buttons off-screen.
- Keep drag handle and queue index always visible and keep A/B deck buttons always visible while removing the extra action buttons (remove, move up/down) from the main card layout.
- Remove the internal `MarqueeText` helper and minor unused helper code so the component is focused on compact markup while preserving the drag handlers and `onLoadToDeck` calls.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` which came up successfully. 
- Captured a UI screenshot using a Playwright script which produced `artifacts/queue-compact.png` to visually verify the compact layout. 
- No unit tests were added or run since this is a UI/markup-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69766b9a20ec832691a8e7180da7bd90)