### PR TITLE
Stabilize deck layout spacing

### DIFF
--- a/raikomix-youtube-dj_1.0/App.tsx
+++ b/raikomix-youtube-dj_1.0/App.tsx
@@ -627,7 +627,7 @@ useEffect(() => {
           )}
 
           <section className="flex-1 flex flex-col items-center justify-center overflow-auto min-h-0 perform-stage">
-            <div className="flex flex-col lg:flex-row items-center perform-stage__inner">
+            <div className="flex flex-col lg:flex-row items-stretch lg:items-start justify-center gap-6 w-full px-4 perform-stage__inner">
              <Deck ref={deckARef} id="A" color="#D0BCFF" eq={deckAEq} effect={deckAEffect} effectWet={deckAEffectWet} effectIntensity={deckAEffectIntensity} onStateUpdate={s => handleDeckStateUpdate('A', s)} onPlayerReady={p => setMasterPlayerA(p)} onTrackEnd={() => handleTrackEnd('A')} />
             <Mixer
                 crossfader={crossfader}

--- a/raikomix-youtube-dj_1.0/components/Deck.tsx
+++ b/raikomix-youtube-dj_1.0/components/Deck.tsx
@@ -624,7 +624,7 @@ const effectNodesRef = useRef<{
     : undefined;
 
   return (
-    <div className="m3-card bg-[#1D1B20] border-white/5 flex flex-col gap-4 shadow-2xl transition-all hover:border-[#D0BCFF]/20 relative overflow-hidden w-full min-w-[320px] max-w-[520px] h-[clamp(480px,70vh,720px)]">
+    <div className="m3-card bg-[#1D1B20] border-white/5 flex flex-col gap-4 shadow-2xl transition-all hover:border-[#D0BCFF]/20 relative overflow-hidden w-full min-w-[320px] max-w-[520px] h-auto">
       <div id={containerId} className="h-0 w-0 overflow-hidden" />
       <audio
         ref={localAudioRef}


### PR DESCRIPTION
### Motivation
- Prevent deck UI from shifting or hiding controls when a song is loaded by removing the fixed card height and tightening the perform-stage layout while preserving symmetry between Deck A and Deck B.

### Description
- Changed the deck card container in `components/Deck.tsx` from a fixed `h-[clamp(480px,70vh,720px)]` to `h-auto` so the card sizes to its content and removes unused vertical space under Hot Cues / Loops without altering control behavior.
- Adjusted the perform stage inner wrapper in `App.tsx` to `items-stretch lg:items-start justify-center gap-6 w-full px-4` to keep Deck A, Mixer, and Deck B aligned, evenly spaced, and visually balanced while maintaining all existing logic and controls.

### Testing
- Launched the dev server with `npm run dev` and confirmed the app served successfully (Vite ready). 
- Captured a UI validation screenshot using a Playwright script (`artifacts/deck-layout.png`) to verify the deck sizing and alignment; the screenshot run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bc4d2c1b08326a8a55cb9940da951)