### PR TITLE
Stabilize mixing console layout under zoom

### DIFF
--- a/raikomix-youtube-dj_1.0/components/Mixer.tsx
+++ b/raikomix-youtube-dj_1.0/components/Mixer.tsx
@@ -268,14 +268,14 @@ const Mixer: React.FC<MixerProps> = ({
   };
 
   return (
-    <div className="m3-card mixer-card h-full flex flex-col bg-[#1D1B20] shadow-2xl border-white/5 shrink-0 p-2 select-none" role="region" aria-label="Mixer Controls">
+    <div className="m3-card mixer-card mixer-shell flex flex-col bg-[#1D1B20] shadow-2xl border-white/5 shrink-0 p-2 select-none" role="region" aria-label="Mixer Controls">
       <div className="flex flex-col items-center gap-0 border-b border-white/5 pb-1 mb-2">
         <h2 className="text-[8px] font-black uppercase tracking-[0.4em] text-[#D0BCFF]">Mixing Console</h2>
       </div>
 
-      <div className="flex-1 flex justify-between gap-1 overflow-hidden">
+      <div className="mixer-main flex justify-between gap-1">
         {/* Channel A Section */}
-        <div className="flex flex-col items-center gap-2 bg-black/10 p-1.5 rounded-xl flex-1 border border-white/5">
+        <div className="mixer-channel flex flex-col items-center gap-2 bg-black/10 p-1.5 rounded-xl border border-white/5">
           <div className="flex flex-col items-center gap-1.5 w-full">
            <Knob label="Trim" value={deckATrim} onChange={onDeckATrimChange} color="#D0BCFF" size="sm" defaultValue={1} />
             <div className="w-full h-px bg-white/5" />
@@ -298,7 +298,7 @@ const Mixer: React.FC<MixerProps> = ({
         </div>
 
         {/* Master Section */}
-        <div className="flex flex-col items-center gap-2 py-2 px-0.5 w-10 bg-black/30 rounded-xl border border-white/5 mx-0.5">
+        <div className="mixer-master flex flex-col items-center gap-2 py-2 px-0.5 w-10 bg-black/30 rounded-xl border border-white/5 mx-0.5">
            <div className="flex flex-col gap-0.5 items-center flex-1 py-1">
              {[...Array(20)].reverse().map((_, i) => {
                const isActive = (deckAPlaying || deckBPlaying) && (Math.random() > (i / 20));
@@ -316,7 +316,7 @@ const Mixer: React.FC<MixerProps> = ({
         </div>
 
         {/* Channel B Section */}
-        <div className="flex flex-col items-center gap-2 bg-black/10 p-1.5 rounded-xl flex-1 border border-white/5">
+        <div className="mixer-channel flex flex-col items-center gap-2 bg-black/10 p-1.5 rounded-xl border border-white/5">
           <div className="flex flex-col items-center gap-1.5 w-full">
             <Knob label="Trim" value={deckBTrim} onChange={onDeckBTrimChange} color="#F2B8B5" size="sm" defaultValue={1} />
             <div className="w-full h-px bg-white/5" />

--- a/raikomix-youtube-dj_1.0/index.html
+++ b/raikomix-youtube-dj_1.0/index.html
@@ -199,6 +199,33 @@
       padding: clamp(12px, 1.6vh, 20px);
     }
 
+    .mixer-card {
+      max-height: min(82vh, 760px);
+    }
+
+    .mixer-shell {
+      width: clamp(200px, 16vw, 260px);
+      height: auto;
+      align-self: flex-start;
+    }
+
+    .mixer-main {
+      flex: 0 0 auto;
+      flex-wrap: nowrap;
+      align-items: stretch;
+      overflow: visible;
+      min-height: 0;
+    }
+
+    .mixer-channel {
+      flex: 1 1 0;
+      min-width: 82px;
+    }
+
+    .mixer-master {
+      flex: 0 0 44px;
+    }
+
     .deck-card {
       gap: clamp(10px, 1.4vh, 16px);
     }


### PR DESCRIPTION
### Motivation
- Prevent the Mixing Console from stretching, reflowing, or clipping controls when the browser zoom level changes so A/B/MST faders and all knobs remain visible and aligned.

### Description
- Add structural classes in `components/Mixer.tsx` (`mixer-shell`, `mixer-main`, `mixer-channel`, `mixer-master`) to isolate the mixer layout and keep the A/B/MST sections on a single row without changing any audio or event logic.
- Add CSS rules in `index.html` to bound mixer sizing and flex behavior (e.g. `max-height: min(82vh, 760px)`, `width: clamp(200px, 16vw, 260px)`, `min-height: 0`, `flex: 0 0 auto`, and `min-width` for channels) to prevent stretch, clipping, and shrink-to-zero bugs.

### Testing
- Launched the dev server with `npm run dev` and confirmed the app served successfully (Vite ready). (layout-only change)
- Captured a headless browser screenshot using Playwright at 1798×850 with zoom set to `1` and produced `artifacts/mixer-layout.png` to validate controls remain visible and alignment is preserved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d04b299c883269c93cd25758fa992)