### PR TITLE
Global themed scrollbar styling to match app UI

### DIFF
--- a/raikomix-youtube-dj_1.0/index.html
+++ b/raikomix-youtube-dj_1.0/index.html
@@ -99,6 +99,35 @@
       outline-offset: 2px;
     }
 
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: rgba(208, 188, 255, 0.75) rgba(16, 14, 22, 0.9);
+    }
+
+    *::-webkit-scrollbar {
+      width: 8px;
+      height: 8px;
+    }
+
+    *::-webkit-scrollbar-track {
+      background: linear-gradient(180deg, rgba(20, 18, 28, 0.95), rgba(9, 8, 14, 0.98));
+      border-radius: 999px;
+      box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.65);
+    }
+
+    *::-webkit-scrollbar-thumb {
+      background: linear-gradient(180deg, rgba(208, 188, 255, 0.9), rgba(119, 102, 186, 0.9));
+      border-radius: 999px;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 0 10px rgba(208, 188, 255, 0.35);
+      transition: background 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    *::-webkit-scrollbar-thumb:hover {
+      background: linear-gradient(180deg, rgba(233, 221, 255, 0.98), rgba(150, 128, 208, 0.98));
+      box-shadow: 0 0 14px rgba(208, 188, 255, 0.55);
+    }
+
     .scrollbar-hide::-webkit-scrollbar { display: none; }
 
     .scrollbar-slim {


### PR DESCRIPTION
### Motivation
- Normalize and replace generic OS scrollbars so all scrollable areas match the app's UX/UI palette and glow treatments shown in the provided examples.

### Description
- Add global scrollbar CSS in `index.html` to set `scrollbar-width`/`scrollbar-color` and `::-webkit-scrollbar`/`::-webkit-scrollbar-track`/`::-webkit-scrollbar-thumb` styles so default scrollbars follow the app theme.
- Retain existing utility classes (`.scrollbar-hide`, `.scrollbar-slim`, `.scrollbar-pads`) while ensuring any element without an explicit class also uses the themed style.
- Styles include thin sizing, rounded tracks, gradient/thumb coloring, subtle borders and glow on hover to match existing UI tokens.

### Testing
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the server started successfully.
- Ran a Playwright script that navigated to `http://127.0.0.1:4173/` and captured a full-page screenshot saved to `artifacts/scrollbars-ui.png`, which completed successfully.
- Committed the change to the repository with a descriptive message and verified the modified file is `index.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dce148ef88326b2a4fba8ac79a0fd)