### PR TITLE
Fix mixer layout overflow on start view

### DIFF
--- a/raikomix-youtube-dj_1.0/App.tsx
+++ b/raikomix-youtube-dj_1.0/App.tsx
@@ -1109,7 +1109,7 @@ useEffect(() => {
             </section>
           )}
 
-          <section className="flex-1 flex flex-col items-center justify-center overflow-hidden min-h-0 min-w-0 perform-stage">
+          <section className="flex-1 flex flex-col items-center justify-center overflow-x-hidden overflow-y-auto min-h-0 min-w-0 perform-stage">
             <div className="flex flex-col lg:flex-row items-stretch lg:items-start justify-center gap-6 w-full px-4 min-h-0 min-w-0 h-full max-h-full perform-stage__inner">
              <div className="perform-stage__deck">
                <Deck ref={deckARef} id="A" color="#D0BCFF" eq={deckAEq} effect={deckAEffect} effectWet={deckAEffectWet} effectIntensity={deckAEffectIntensity} onStateUpdate={s => handleDeckStateUpdate('A', s)} onPlayerReady={p => setMasterPlayerA(p)} onTrackEnd={() => handleTrackEnd('A')} />

--- a/raikomix-youtube-dj_1.0/index.html
+++ b/raikomix-youtube-dj_1.0/index.html
@@ -213,11 +213,13 @@
 
     .perform-stage {
       flex: 1 1 auto;
+      overflow-y: auto;
     }
 
     .perform-stage__inner {
-      height: 100%;
-      max-height: 100%;
+      height: auto;
+      min-height: 100%;
+      max-height: none;
       align-items: stretch;
       gap: clamp(12px, 2vw, 24px);
       margin-top: clamp(4px, 0.8vh, 10px);
@@ -246,7 +248,7 @@
     }
 
     .mixer-card {
-      max-height: min(82vh, 760px);
+      max-height: none;
       min-height: 0;
     }
 


### PR DESCRIPTION
### Motivation
- The mixing console controls (Deck A/B volume, MST, crossfader and related knobs) could overlap UI elements on smaller laptop windows or when zoomed, making the start view unusable.  
- The goal was to fix only the start-view layout so the UI is stable across laptop and larger screens without changing library/perform/queue logic or functionality.

### Description
- Allow the performance stage to scroll by adding `overflow-x-hidden overflow-y-auto` to the perform-stage section in `App.tsx` so the mixer can be scrolled vertically when space is constrained.  
- Relax layout sizing in `index.html` CSS by setting `.perform-stage` to `overflow-y: auto`, making `.perform-stage__inner` `height: auto` with `min-height: 100%` and removing the `max-height` cap on `.mixer-card` so mixer controls no longer get clipped.  
- No behavioral or state changes were made to library, queue, or mixing logic; only layout and CSS adjustments were applied to prevent overlap.

### Testing
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the app served successfully (Vite reported ready).  
- Ran a Playwright script that opened `http://127.0.0.1:4173/` at `1440x900` and captured a full-page screenshot to `artifacts/mixer-layout.png`, verifying the layout change visually; the capture completed successfully.  
- No automated unit tests were added or modified as this is a UI/layout-only fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e09484eb48326b2b2fdd3787a52b3)