### PR TITLE
Fix layout regressions: restore Library width, contain track actions, and stabilize Mixer vertical layout

### DIFF
--- a/raikomix-youtube-dj_1.0/App.tsx
+++ b/raikomix-youtube-dj_1.0/App.tsx
@@ -1016,7 +1016,7 @@ useEffect(() => {
         <div
           className="app-shell__main min-h-0"
           style={{
-            '--left-w': libraryOpen ? 'clamp(280px,22vw,360px)' : '0px',
+            '--left-w': libraryOpen ? 'clamp(320px,26vw,420px)' : '0px',
             '--right-w': viewMode === 'LIBRARY' && queueOpen ? 'clamp(240px,18vw,300px)' : '0px'
           } as React.CSSProperties}
         >

--- a/raikomix-youtube-dj_1.0/components/LibraryPanel.tsx
+++ b/raikomix-youtube-dj_1.0/components/LibraryPanel.tsx
@@ -481,7 +481,7 @@ const LibraryPanel: React.FC<LibraryPanelProps> = ({
             title={tooltipText}
             tabIndex={0}
             onTouchStart={(event) => event.currentTarget.focus()}
-            className={`group flex gap-3 items-center p-3 rounded-xl border transition-all relative ${
+            className={`group grid grid-cols-[auto_auto_minmax(0,1fr)_auto] items-center gap-3 p-4 min-h-[72px] rounded-xl border transition-all relative overflow-hidden ${
               isSelected ? 'bg-[#D0BCFF]/10 border-[#D0BCFF]/50' : 'bg-black/20 border-white/5 hover:border-white/20'
             } ${playedOpacity}`}
           >
@@ -503,22 +503,24 @@ const LibraryPanel: React.FC<LibraryPanelProps> = ({
               <div className="text-[11px] font-bold text-white truncate leading-tight group-hover:text-[#D0BCFF] transition-colors">{t.title}</div>
               <div className="text-[9px] text-gray-500 truncate uppercase font-bold tracking-tighter">{t.author}</div>
             </div>
-             {hasBeenPlayed && (
-              <span className="text-[8px] font-black uppercase tracking-widest text-gray-500 border border-white/10 rounded-full px-2 py-1">
-                Played
-              </span>
-            )}
-            <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-all">
-              <button 
-                onClick={() => onAddToQueue(t)} 
-                className="w-7 h-7 rounded-lg bg-white/10 text-white flex items-center justify-center hover:bg-white/20 transition-all"
-                title="Add to Queue"
-              >
-                <span className="material-symbols-outlined text-sm">playlist_add</span>
-              </button>
-              <button onClick={() => onLoadToDeck(t, 'A')} className="w-7 h-7 rounded-lg bg-[#D0BCFF] text-black text-[10px] font-black hover:scale-110 active:scale-90 transition-all">A</button>
-              <button onClick={() => onLoadToDeck(t, 'B')} className="w-7 h-7 rounded-lg bg-[#F2B8B5] text-black text-[10px] font-black hover:scale-110 active:scale-90 transition-all">B</button>
-              <button onClick={() => onRemove(t.id)} className="w-7 h-7 rounded-lg bg-red-500/10 text-red-400 flex items-center justify-center hover:bg-red-500/30 transition-all" title="Remove"><span className="material-symbols-outlined text-sm">delete</span></button>
+            <div className="flex items-center justify-end gap-2 min-w-[136px] shrink-0">
+              {hasBeenPlayed && (
+                <span className="text-[8px] font-black uppercase tracking-widest text-gray-500 border border-white/10 rounded-full px-2 py-1 shrink-0">
+                  Played
+                </span>
+              )}
+              <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-all">
+                <button 
+                  onClick={() => onAddToQueue(t)} 
+                  className="w-7 h-7 rounded-lg bg-white/10 text-white flex items-center justify-center hover:bg-white/20 transition-all"
+                  title="Add to Queue"
+                >
+                  <span className="material-symbols-outlined text-sm">playlist_add</span>
+                </button>
+                <button onClick={() => onLoadToDeck(t, 'A')} className="w-7 h-7 rounded-lg bg-[#D0BCFF] text-black text-[10px] font-black hover:scale-110 active:scale-90 transition-all">A</button>
+                <button onClick={() => onLoadToDeck(t, 'B')} className="w-7 h-7 rounded-lg bg-[#F2B8B5] text-black text-[10px] font-black hover:scale-110 active:scale-90 transition-all">B</button>
+                <button onClick={() => onRemove(t.id)} className="w-7 h-7 rounded-lg bg-red-500/10 text-red-400 flex items-center justify-center hover:bg-red-500/30 transition-all" title="Remove"><span className="material-symbols-outlined text-sm">delete</span></button>
+              </div>
             </div>
             <div className="pointer-events-none absolute left-12 top-full z-10 mt-2 w-64 rounded-xl border border-white/10 bg-black/90 p-3 text-[9px] text-white opacity-0 shadow-xl transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
               <div className="font-bold text-[#D0BCFF] mb-1">Track Details</div>

--- a/raikomix-youtube-dj_1.0/components/Mixer.tsx
+++ b/raikomix-youtube-dj_1.0/components/Mixer.tsx
@@ -268,12 +268,12 @@ const Mixer: React.FC<MixerProps> = ({
   };
 
   return (
-    <div className="m3-card mixer-card mixer-shell flex flex-col bg-[#1D1B20] shadow-2xl border-white/5 shrink-0 p-2 select-none" role="region" aria-label="Mixer Controls">
-      <div className="flex flex-col items-center gap-0 border-b border-white/5 pb-1 mb-2">
+    <div className="m3-card mixer-card mixer-shell bg-[#1D1B20] shadow-2xl border-white/5 shrink-0 p-2 select-none" role="region" aria-label="Mixer Controls">
+      <div className="mixer-header flex flex-col items-center gap-0 border-b border-white/5 pb-1 mb-2">
         <h2 className="text-[8px] font-black uppercase tracking-[0.4em] text-[#D0BCFF]">Mixing Console</h2>
       </div>
 
-      <div className="mixer-upper">
+      <div className="mixer-content">
         <div className="mixer-top">
           <div className="mixer-topgrid grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-stretch gap-1 min-h-0">
             {/* Channel A Section */}
@@ -349,7 +349,7 @@ const Mixer: React.FC<MixerProps> = ({
           </div>
       </div>
 
-      <div className="mixer-lower">
+      <div className="mixer-footer">
         {/* Crossfader Section - Enhanced visual design */}
         <div className="mt-4 space-y-2 pt-2 border-t border-white/5 relative">
           <div className="flex justify-between gap-1 p-0.5 bg-black/30 rounded-lg mb-1">

--- a/raikomix-youtube-dj_1.0/index.html
+++ b/raikomix-youtube-dj_1.0/index.html
@@ -324,7 +324,24 @@
       align-self: stretch;
       min-width: 0;
       display: grid;
-      grid-template-rows: auto 1fr auto;
+      grid-template-rows: auto minmax(0, 1fr) auto;
+      min-height: 0;
+    }
+
+    .mixer-header {
+      min-height: 0;
+    }
+
+    .mixer-content {
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      gap: clamp(8px, 1vh, 14px);
+    }
+
+    .mixer-footer {
+      min-height: 0;
     }
 
     .mixer-upper {
@@ -369,14 +386,15 @@
     }
 
     .mixer-faderbank {
-      margin-top: 10px;
+      margin-top: 6px;
       padding: 0 2px;
-      height: clamp(170px, 24vh, 220px);
+      height: clamp(140px, 22vh, 210px);
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
       align-items: end;
       justify-items: center;
       gap: 12px;
+      min-height: 0;
     }
 
     .mixer-fadercell {


### PR DESCRIPTION
### Motivation
- A recent responsive grid refactor made the left Library panel and library track rows too narrow and allowed the track delete control to escape when a `Played` badge appears.  
- The Mixer grid distribution caused vertical faders to overlap knob/handle areas on laptop heights and produced excessive empty vertical spacing on tall displays.  
- The goal is to revert only layout/markup and CSS so rows, badges, and mixer sections behave and feel like the pre-refactor layout without changing logic or handlers.

### Description
- Adjusted the left panel sizing by increasing the CSS variable used in `App.tsx` from `clamp(280px,22vw,360px)` to `clamp(320px,26vw,420px)` to restore desktop Library width and reduce cramped rows (`App.tsx`).
- Reworked the library track row markup and spacing in `LibraryPanel.tsx` by switching the row container to a grid (`grid-cols-[auto_auto_minmax(0,1fr)_auto]`), increasing padding and `min-h-[72px]`, adding `overflow-hidden` and reserving a fixed actions rail (`min-w-[136px] shrink-0`) so the `Played` badge and action buttons are always contained inside the rounded card without overflow.
- Restructured the Mixer layout markup in `Mixer.tsx` to explicitly expose three logical sections (`.mixer-header`, `.mixer-content`, `.mixer-footer`) matching the intended grid rows so CSS can align to those three children, and removed redundant `flex-col` on the root to avoid conflicts.
- Tuned mixer CSS in `index.html` to use `grid-template-rows: auto minmax(0, 1fr) auto` for `.mixer-shell`, set `min-height:0`/`min-width:0` on relevant containers, reduced and capped the faderbank sizing (`height: clamp(140px, 22vh, 210px)`), and adjusted spacing so faders cannot overlap knobs at typical laptop heights and do not sit too low on tall screens.
- Ensured `min-width:0` / `min-height:0` and sensible `overflow` rules on key containers to prevent unexpected clipping or overflow when badges appear.

### Testing
- No automated tests were executed for this layout-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f395649e883268d449492fbb3db29)