### PR TITLE
Redesign central stage layout density and scaling

### DIFF
--- a/raikomix-youtube-dj_1.0/App.tsx
+++ b/raikomix-youtube-dj_1.0/App.tsx
@@ -1122,8 +1122,8 @@ useEffect(() => {
           )}
 
           <section className="perform-stage min-h-0 min-w-0">
-            <div className="perform-stage__inner w-full min-h-0">
-             <div className="perform-stage__deck">
+            <div className="perform-stage__inner central-stage w-full min-h-0">
+             <div className="perform-stage__deck central-stage__deck">
                <Deck ref={deckARef} id="A" color="#D0BCFF" eq={deckAEq} effect={deckAEffect} effectWet={deckAEffectWet} effectIntensity={deckAEffectIntensity} onStateUpdate={s => handleDeckStateUpdate('A', s)} onPlayerReady={p => setMasterPlayerA(p)} onTrackEnd={() => handleTrackEnd('A')} />
              </div>
             <Mixer
@@ -1155,7 +1155,7 @@ useEffect(() => {
                 onDeckAEqChange={(k, v) => setDeckAEq(p => ({...p, [k]: v}))}
                 onDeckBEqChange={(k, v) => setDeckBEq(p => ({...p, [k]: v}))}
               />
-                 <div className="perform-stage__deck">
+                 <div className="perform-stage__deck central-stage__deck">
                    <Deck ref={deckBRef} id="B" color="#F2B8B5" eq={deckBEq} effect={deckBEffect} effectWet={deckBEffectWet} effectIntensity={deckBEffectIntensity} onStateUpdate={s => handleDeckStateUpdate('B', s)} onPlayerReady={p => setMasterPlayerB(p)} onTrackEnd={() => handleTrackEnd('B')} />
                  </div>
             </div>

--- a/raikomix-youtube-dj_1.0/components/Mixer.tsx
+++ b/raikomix-youtube-dj_1.0/components/Mixer.tsx
@@ -268,7 +268,7 @@ const Mixer: React.FC<MixerProps> = ({
   };
 
   return (
-    <div className="m3-card mixer-card mixer-shell bg-[#1D1B20] shadow-2xl border-white/5 shrink-0 p-2 select-none" role="region" aria-label="Mixer Controls">
+    <div className="m3-card mixer-card mixer-shell central-stage__mixer bg-[#1D1B20] shadow-2xl border-white/5 shrink-0 p-2 select-none" role="region" aria-label="Mixer Controls">
       <div className="mixer-header flex flex-col items-center gap-0 border-b border-white/5 pb-1 mb-2">
         <h2 className="text-[8px] font-black uppercase tracking-[0.4em] text-[#D0BCFF]">Mixing Console</h2>
       </div>

--- a/raikomix-youtube-dj_1.0/index.html
+++ b/raikomix-youtube-dj_1.0/index.html
@@ -261,34 +261,58 @@
       height: 100%;
       display: flex;
       justify-content: center;
+      align-items: center;
       min-height: 0;
       overflow: hidden;
+      container-type: size;
+      container-name: central-stage;
     }
 
-    .perform-stage__inner {
-      --mixer-width: 220px;
+    .central-stage {
+      --mixer-width: 224px;
       --deck-min: 360px;
+      --central-gap: 20px;
+      --central-padding-block: 16px;
+      --central-padding-inline: 18px;
+      --mixer-gap: 10px;
+      --mixer-fader-height: 190px;
+      --mixer-meter-height: 110px;
+      --central-stage-scale: 1;
       display: grid;
       grid-template-columns: minmax(var(--deck-min), 1fr) var(--mixer-width) minmax(var(--deck-min), 1fr);
       align-items: stretch;
-      gap: clamp(12px, 2vw, 24px);
+      gap: var(--central-gap);
       height: 100%;
       min-height: 0;
-      padding: clamp(12px, 2vh, 18px) clamp(12px, 1.6vw, 20px);
+      padding: var(--central-padding-block) var(--central-padding-inline);
+      transform: scale(var(--central-stage-scale));
+      transform-origin: center;
     }
 
-    .perform-stage__inner > * {
+    .perform-stage__inner > *,
+    .central-stage > * {
       min-width: 0;
       min-height: 0;
     }
 
     .perform-stage__deck {
       display: flex;
-      align-items: flex-start;
+      align-items: stretch;
       min-width: 0;
       width: 100%;
       max-width: none;
       flex: 1 1 auto;
+    }
+
+    .central-stage__deck > * {
+      height: 100%;
+      min-height: 0;
+      width: 100%;
+    }
+
+    .central-stage__mixer {
+      height: 100%;
+      min-height: 0;
     }
 
     .deck-title-stack {
@@ -303,7 +327,7 @@
     .deck-card,
     .mixer-card {
       max-height: 100%;
-      padding: clamp(12px, 1.6vh, 20px);
+      padding: 14px;
     }
 
     .deck-card {
@@ -324,7 +348,9 @@
       align-self: stretch;
       min-width: 0;
       display: grid;
-      grid-template-rows: auto minmax(0, 1fr) auto;
+      grid-template-rows: auto auto auto;
+      align-content: center;
+      row-gap: var(--mixer-gap);
       min-height: 0;
     }
 
@@ -335,10 +361,10 @@
     .mixer-content {
       min-height: 0;
       display: grid;
-      grid-template-rows: auto minmax(0, 1fr);
-      align-content: start;
+      grid-template-rows: auto var(--mixer-fader-height);
+      align-content: center;
       justify-items: stretch;
-      gap: clamp(6px, 0.9vh, 10px);
+      gap: var(--mixer-gap);
     }
 
     .mixer-footer {
@@ -380,15 +406,14 @@
     }
 
     .mixer-meter {
-      height: clamp(92px, 14vh, 120px);
+      height: var(--mixer-meter-height);
       overflow: hidden;
     }
 
     .mixer-faderbank {
       margin-top: 0;
       padding: 0 2px;
-      height: min(100%, clamp(140px, 22vh, 210px));
-      max-height: clamp(140px, 22vh, 210px);
+      height: var(--mixer-fader-height);
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
       align-items: end;
@@ -419,11 +444,55 @@
     }
 
     .deck-card {
-      gap: clamp(10px, 1.4vh, 16px);
+      gap: 12px;
     }
 
     .waveform-display {
-      height: clamp(4.5rem, 10vh, 6rem);
+      height: 5rem;
+    }
+
+    /* Central Stage density modes:
+       - Comfort (default): generous gaps/padding.
+       - Compact: triggered by height thresholds to tighten spacing.
+       Safe scale: if height is still tight, scale down the central stage wrapper only. */
+    @container central-stage (max-height: 820px) {
+      .central-stage {
+        --central-gap: 14px;
+        --central-padding-block: 12px;
+        --central-padding-inline: 12px;
+        --mixer-gap: 8px;
+        --mixer-fader-height: 170px;
+        --mixer-meter-height: 96px;
+      }
+
+      .central-stage .mixer-card,
+      .central-stage .deck-card {
+        padding: 12px;
+      }
+
+      .central-stage .mixer-topgrid {
+        gap: 4px;
+      }
+
+      .central-stage .mixer-channel {
+        padding: 6px;
+        gap: 6px;
+      }
+
+      .central-stage .mixer-footer .mt-4 {
+        margin-top: 10px;
+        padding-top: 6px;
+      }
+
+      .central-stage .mixer-footer .mt-3 {
+        margin-top: 8px;
+      }
+    }
+
+    @container central-stage (max-height: 720px) {
+      .central-stage {
+        --central-stage-scale: 0.94;
+      }
     }
 
     /* Vertical Text Utility */
@@ -458,7 +527,7 @@
     }
 
     @media (max-width: 1280px) {
-      .perform-stage__inner {
+      .central-stage {
         --mixer-width: 210px;
         --deck-min: 320px;
       }
@@ -469,7 +538,7 @@
         overflow-y: auto;
       }
 
-      .perform-stage__inner {
+      .central-stage {
         grid-template-columns: minmax(0, 1fr);
         grid-auto-rows: auto;
       }
@@ -485,8 +554,50 @@
     }
 
     @media (max-width: 768px) {
-      .perform-stage__inner {
-        padding: clamp(8px, 1.4vh, 14px);
+      .central-stage {
+        --central-padding-block: 10px;
+        --central-padding-inline: 10px;
+        --central-gap: 12px;
+      }
+    }
+
+    @media (max-height: 820px) {
+      .central-stage {
+        --central-gap: 14px;
+        --central-padding-block: 12px;
+        --central-padding-inline: 12px;
+        --mixer-gap: 8px;
+        --mixer-fader-height: 170px;
+        --mixer-meter-height: 96px;
+      }
+
+      .central-stage .mixer-card,
+      .central-stage .deck-card {
+        padding: 12px;
+      }
+
+      .central-stage .mixer-topgrid {
+        gap: 4px;
+      }
+
+      .central-stage .mixer-channel {
+        padding: 6px;
+        gap: 6px;
+      }
+
+      .central-stage .mixer-footer .mt-4 {
+        margin-top: 10px;
+        padding-top: 6px;
+      }
+
+      .central-stage .mixer-footer .mt-3 {
+        margin-top: 8px;
+      }
+    }
+
+    @media (max-height: 720px) {
+      .central-stage {
+        --central-stage-scale: 0.94;
       }
     }
   </style>


### PR DESCRIPTION
### Motivation
- Provide a deterministic, pro-DJ central console layout so Deck A + Mixer + Deck B align to the same top/bottom baselines and never overlap or clip across zoom/height variations. 
- Ensure mixer content is split into explicit bands (EQ / Fader / Footer), the footer is always visible, and faders keep a constant visual height on tall screens. 
- Keep all audio logic, control order, and visual theme unchanged while making sizing/spacing stable and predictable.

### Description
- Added a `central-stage` wrapper and `central-stage__deck` / `central-stage__mixer` hooks by updating `App.tsx` and `components/Mixer.tsx` so the central console is managed as one coherent unit. 
- Rewrote perform-stage CSS in `index.html` to use a grid with explicit rows and CSS variables for mixer bands (`--mixer-fader-height`, `--mixer-meter-height`), fixed band heights, and unified padding/gap tokens. 
- Implemented two density modes via container queries on the central-stage container (`@container central-stage (max-height: 820px)` and `720px`) to tighten spacing in Compact mode and a safe-scale fallback by toggling `--central-stage-scale` to uniformly scale the central-stage wrapper. 
- Removed conflicting dynamic `clamp()` height rules for mixer faders/meters in favor of the new variables and deterministic grid rows; preserved all JS/state/behavior and did only minimal class additions.

### Testing
- Started the dev server with `npm run dev` which reported Vite ready and accessible, and the command completed successfully. 
- Ran a visual smoke check using Playwright that navigated to `http://127.0.0.1:4173/` and produced a screenshot at `artifacts/central-stage.png`, confirming the central wrapper renders without errors. 
- Committed changes (`git commit`) after verifying files modified were only `index.html`, `App.tsx`, and `components/Mixer.tsx`, and the automated steps above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f5b9af29c83268c1df4a3fd6f3214)