### PR TITLE
Redesign central console layout as unified instrument panel

### DIFF
--- a/raikomix-youtube-dj_1.0/App.tsx
+++ b/raikomix-youtube-dj_1.0/App.tsx
@@ -1123,41 +1123,43 @@ useEffect(() => {
 
           <section className="perform-stage min-h-0 min-w-0">
             <div className="perform-stage__inner central-stage w-full min-h-0">
-             <div className="perform-stage__deck central-stage__deck">
-               <Deck ref={deckARef} id="A" color="#D0BCFF" eq={deckAEq} effect={deckAEffect} effectWet={deckAEffectWet} effectIntensity={deckAEffectIntensity} onStateUpdate={s => handleDeckStateUpdate('A', s)} onPlayerReady={p => setMasterPlayerA(p)} onTrackEnd={() => handleTrackEnd('A')} />
-             </div>
-            <Mixer
-                crossfader={crossfader}
-                onCrossfaderChange={setCrossfader}
-                crossfaderCurve={xFaderCurve}
-                onCurveChange={setXFaderCurve}
-                autoDjEnabled={autoDjEnabled}
-                onToggleAutoDj={() => setAutoDjEnabled(prev => !prev)}
-                mixLeadSeconds={mixLeadSeconds}
-                mixDurationSeconds={mixDurationSeconds}
-                onMixLeadChange={handleMixLeadChange}
-                onMixDurationChange={handleMixDurationChange}
-                queueLength={queue.length}
-                masterVolume={masterVolume}
-                onMasterVolumeChange={setMasterVolume}
-                deckAVolume={deckAVolume}
-                onDeckAVolumeChange={setDeckAVolume}
-                deckBVolume={deckBVolume}
-                onDeckBVolumeChange={setDeckBVolume}
-                deckAPlaying={deckAState?.playing || false}
-                deckBPlaying={deckBState?.playing || false}
-                deckATrim={deckAEffectWet}
-                deckBTrim={deckBEffectWet}
-                onDeckATrimChange={setDeckAEffectWet}
-                onDeckBTrimChange={setDeckBEffectWet}
-                deckAEq={deckAEq}
-                deckBEq={deckBEq}
-                onDeckAEqChange={(k, v) => setDeckAEq(p => ({...p, [k]: v}))}
-                onDeckBEqChange={(k, v) => setDeckBEq(p => ({...p, [k]: v}))}
-              />
-                 <div className="perform-stage__deck central-stage__deck">
-                   <Deck ref={deckBRef} id="B" color="#F2B8B5" eq={deckBEq} effect={deckBEffect} effectWet={deckBEffectWet} effectIntensity={deckBEffectIntensity} onStateUpdate={s => handleDeckStateUpdate('B', s)} onPlayerReady={p => setMasterPlayerB(p)} onTrackEnd={() => handleTrackEnd('B')} />
-                 </div>
+              <div className="central-stage__panel">
+                <div className="perform-stage__deck central-stage__deck">
+                  <Deck ref={deckARef} id="A" color="#D0BCFF" eq={deckAEq} effect={deckAEffect} effectWet={deckAEffectWet} effectIntensity={deckAEffectIntensity} onStateUpdate={s => handleDeckStateUpdate('A', s)} onPlayerReady={p => setMasterPlayerA(p)} onTrackEnd={() => handleTrackEnd('A')} />
+                </div>
+                <Mixer
+                  crossfader={crossfader}
+                  onCrossfaderChange={setCrossfader}
+                  crossfaderCurve={xFaderCurve}
+                  onCurveChange={setXFaderCurve}
+                  autoDjEnabled={autoDjEnabled}
+                  onToggleAutoDj={() => setAutoDjEnabled(prev => !prev)}
+                  mixLeadSeconds={mixLeadSeconds}
+                  mixDurationSeconds={mixDurationSeconds}
+                  onMixLeadChange={handleMixLeadChange}
+                  onMixDurationChange={handleMixDurationChange}
+                  queueLength={queue.length}
+                  masterVolume={masterVolume}
+                  onMasterVolumeChange={setMasterVolume}
+                  deckAVolume={deckAVolume}
+                  onDeckAVolumeChange={setDeckAVolume}
+                  deckBVolume={deckBVolume}
+                  onDeckBVolumeChange={setDeckBVolume}
+                  deckAPlaying={deckAState?.playing || false}
+                  deckBPlaying={deckBState?.playing || false}
+                  deckATrim={deckAEffectWet}
+                  deckBTrim={deckBEffectWet}
+                  onDeckATrimChange={setDeckAEffectWet}
+                  onDeckBTrimChange={setDeckBEffectWet}
+                  deckAEq={deckAEq}
+                  deckBEq={deckBEq}
+                  onDeckAEqChange={(k, v) => setDeckAEq(p => ({...p, [k]: v}))}
+                  onDeckBEqChange={(k, v) => setDeckBEq(p => ({...p, [k]: v}))}
+                />
+                <div className="perform-stage__deck central-stage__deck">
+                  <Deck ref={deckBRef} id="B" color="#F2B8B5" eq={deckBEq} effect={deckBEffect} effectWet={deckBEffectWet} effectIntensity={deckBEffectIntensity} onStateUpdate={s => handleDeckStateUpdate('B', s)} onPlayerReady={p => setMasterPlayerB(p)} onTrackEnd={() => handleTrackEnd('B')} />
+                </div>
+              </div>
             </div>
           </section>
 

--- a/raikomix-youtube-dj_1.0/components/Mixer.tsx
+++ b/raikomix-youtube-dj_1.0/components/Mixer.tsx
@@ -269,91 +269,87 @@ const Mixer: React.FC<MixerProps> = ({
 
   return (
     <div className="m3-card mixer-card mixer-shell central-stage__mixer bg-[#1D1B20] shadow-2xl border-white/5 shrink-0 p-2 select-none" role="region" aria-label="Mixer Controls">
-      <div className="mixer-header flex flex-col items-center gap-0 border-b border-white/5 pb-1 mb-2">
+      <div className="mixer-header flex flex-col items-center gap-0 border-b border-white/5 pb-1">
         <h2 className="text-[8px] font-black uppercase tracking-[0.4em] text-[#D0BCFF]">Mixing Console</h2>
       </div>
 
-      <div className="mixer-content">
-        <div className="mixer-upper">
-          <div className="mixer-top">
-            <div className="mixer-topgrid grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-stretch gap-1 min-h-0">
-              {/* Channel A Section */}
-              <div className="mixer-channel bg-black/10 p-1.5 rounded-xl border border-white/5 w-full min-w-0 flex flex-col items-center gap-2">
-                <div className="flex flex-col items-center gap-1.5 w-full">
-                  <Knob label="Trim" value={deckATrim} onChange={onDeckATrimChange} color="#D0BCFF" size="sm" defaultValue={1} />
-                  <div className="w-full h-px bg-white/5" />
-                  <div className="flex flex-col gap-1.5">
-                    <Knob label="Hi" value={deckAEq.hi} onChange={(v) => onDeckAEqChange('hi', v)} color="#D0BCFF" />
-                    <Knob label="Mid" value={deckAEq.mid} onChange={(v) => onDeckAEqChange('mid', v)} color="#D0BCFF" />
-                    <Knob label="Low" value={deckAEq.low} onChange={(v) => onDeckAEqChange('low', v)} color="#D0BCFF" />
-                    <Knob label="Color" value={deckAEq.filter} onChange={(v) => onDeckAEqChange('filter', v)} color="#D0BCFF" min={-1} max={1} defaultValue={0} />
-                  </div>
-                </div>
-
-                <button 
-                  onClick={() => setCueA(!cueA)}
-                  className={`w-10 h-5 rounded-md text-[7px] font-black uppercase tracking-tighter transition-all border ${cueA ? 'bg-orange-500 border-orange-400 text-white shadow-[0_0_8px_rgba(249,115,22,0.4)]' : 'bg-black/40 border-white/5 text-gray-500'}`}
-                >
-                  Cue
-                </button>
-              </div>
-
-              {/* Master Section */}
-              <div className="mixer-master-top w-10 bg-black/30 rounded-xl border border-white/5 mx-0.5 justify-self-center p-2">
-                <div className="mixer-meter flex flex-col gap-0.5 items-center py-1">
-                  {[...Array(20)].reverse().map((_, i) => {
-                    const isActive = (deckAPlaying || deckBPlaying) && (Math.random() > (i / 20));
-                    let barColor = 'bg-green-900/10';
-                    if (isActive) {
-                      if (i > 16) barColor = 'bg-red-500 shadow-[0_0_6px_red]';
-                      else if (i > 12) barColor = 'bg-orange-500 shadow-[0_0_4px_orange]';
-                      else barColor = 'bg-green-500 shadow-[0_0_3px_#22c55e]';
-                    }
-                    return <div key={i} className={`w-2 h-0.5 rounded-[0.5px] transition-all duration-75 ${barColor}`} />;
-                  })}
-                </div>
-              </div>
-
-              {/* Channel B Section */}
-              <div className="mixer-channel bg-black/10 p-1.5 rounded-xl border border-white/5 w-full min-w-0 flex flex-col items-center gap-2">
-                <div className="flex flex-col items-center gap-1.5 w-full">
-                  <Knob label="Trim" value={deckBTrim} onChange={onDeckBTrimChange} color="#F2B8B5" size="sm" defaultValue={1} />
-                  <div className="w-full h-px bg-white/5" />
-                  <div className="flex flex-col gap-1.5">
-                    <Knob label="Hi" value={deckBEq.hi} onChange={(v) => onDeckBEqChange('hi', v)} color="#F2B8B5" />
-                    <Knob label="Mid" value={deckBEq.mid} onChange={(v) => onDeckBEqChange('mid', v)} color="#F2B8B5" />
-                    <Knob label="Low" value={deckBEq.low} onChange={(v) => onDeckBEqChange('low', v)} color="#F2B8B5" />
-                    <Knob label="Color" value={deckBEq.filter} onChange={(v) => onDeckBEqChange('filter', v)} color="#F2B8B5" min={-1} max={1} defaultValue={0} />
-                  </div>
-                </div>
-
-                <button 
-                  onClick={() => setCueB(!cueB)}
-                  className={`w-10 h-5 rounded-md text-[7px] font-black uppercase tracking-tighter transition-all border ${cueB ? 'bg-orange-500 border-orange-400 text-white shadow-[0_0_8px_rgba(249,115,22,0.4)]' : 'bg-black/40 border-white/5 text-gray-500'}`}
-                >
-                  Cue
-                </button>
+      <div className="mixer-band mixer-band--eq">
+        <div className="mixer-topgrid grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-stretch gap-1 min-h-0">
+          {/* Channel A Section */}
+          <div className="mixer-channel bg-black/10 p-1.5 rounded-xl border border-white/5 w-full min-w-0 flex flex-col items-center gap-2">
+            <div className="flex flex-col items-center gap-1.5 w-full">
+              <Knob label="Trim" value={deckATrim} onChange={onDeckATrimChange} color="#D0BCFF" size="sm" defaultValue={1} />
+              <div className="w-full h-px bg-white/5" />
+              <div className="flex flex-col gap-1.5">
+                <Knob label="Hi" value={deckAEq.hi} onChange={(v) => onDeckAEqChange('hi', v)} color="#D0BCFF" />
+                <Knob label="Mid" value={deckAEq.mid} onChange={(v) => onDeckAEqChange('mid', v)} color="#D0BCFF" />
+                <Knob label="Low" value={deckAEq.low} onChange={(v) => onDeckAEqChange('low', v)} color="#D0BCFF" />
+                <Knob label="Color" value={deckAEq.filter} onChange={(v) => onDeckAEqChange('filter', v)} color="#D0BCFF" min={-1} max={1} defaultValue={0} />
               </div>
             </div>
-          </div>
-        </div>
 
-        <div className="mixer-faderbank">
-          <div className="mixer-fadercell mixer-fadercell--a">
-            <Fader label="A" value={deckAVolume} onChange={onDeckAVolumeChange} color="#D0BCFF" height="h-28" />
+            <button 
+              onClick={() => setCueA(!cueA)}
+              className={`w-10 h-5 rounded-md text-[7px] font-black uppercase tracking-tighter transition-all border ${cueA ? 'bg-orange-500 border-orange-400 text-white shadow-[0_0_8px_rgba(249,115,22,0.4)]' : 'bg-black/40 border-white/5 text-gray-500'}`}
+            >
+              Cue
+            </button>
           </div>
-          <div className="mixer-fadercell mixer-fadercell--m">
-            <Fader label="MST" value={masterVolume} onChange={onMasterVolumeChange} color="#FFFFFF" height="h-24" />
-          </div>
-          <div className="mixer-fadercell mixer-fadercell--b">
-            <Fader label="B" value={deckBVolume} onChange={onDeckBVolumeChange} color="#F2B8B5" height="h-28" />
+
+          <div className="mixer-center-spine bg-black/30 rounded-xl border border-white/5 mx-0.5" aria-hidden="true" />
+
+          {/* Channel B Section */}
+          <div className="mixer-channel bg-black/10 p-1.5 rounded-xl border border-white/5 w-full min-w-0 flex flex-col items-center gap-2">
+            <div className="flex flex-col items-center gap-1.5 w-full">
+              <Knob label="Trim" value={deckBTrim} onChange={onDeckBTrimChange} color="#F2B8B5" size="sm" defaultValue={1} />
+              <div className="w-full h-px bg-white/5" />
+              <div className="flex flex-col gap-1.5">
+                <Knob label="Hi" value={deckBEq.hi} onChange={(v) => onDeckBEqChange('hi', v)} color="#F2B8B5" />
+                <Knob label="Mid" value={deckBEq.mid} onChange={(v) => onDeckBEqChange('mid', v)} color="#F2B8B5" />
+                <Knob label="Low" value={deckBEq.low} onChange={(v) => onDeckBEqChange('low', v)} color="#F2B8B5" />
+                <Knob label="Color" value={deckBEq.filter} onChange={(v) => onDeckBEqChange('filter', v)} color="#F2B8B5" min={-1} max={1} defaultValue={0} />
+              </div>
+            </div>
+
+            <button 
+              onClick={() => setCueB(!cueB)}
+              className={`w-10 h-5 rounded-md text-[7px] font-black uppercase tracking-tighter transition-all border ${cueB ? 'bg-orange-500 border-orange-400 text-white shadow-[0_0_8px_rgba(249,115,22,0.4)]' : 'bg-black/40 border-white/5 text-gray-500'}`}
+            >
+              Cue
+            </button>
           </div>
         </div>
       </div>
 
-      <div className="mixer-footer">
+      <div className="mixer-band mixer-band--faders">
+        <div className="mixer-fadercell mixer-fadercell--a">
+          <Fader label="A" value={deckAVolume} onChange={onDeckAVolumeChange} color="#D0BCFF" height="h-[var(--mixer-fader-height)]" />
+        </div>
+        <div className="mixer-masterstrip">
+          <div className="mixer-meter flex flex-col gap-0.5 items-center py-1">
+            {[...Array(20)].reverse().map((_, i) => {
+              const isActive = (deckAPlaying || deckBPlaying) && (Math.random() > (i / 20));
+              let barColor = 'bg-green-900/10';
+              if (isActive) {
+                if (i > 16) barColor = 'bg-red-500 shadow-[0_0_6px_red]';
+                else if (i > 12) barColor = 'bg-orange-500 shadow-[0_0_4px_orange]';
+                else barColor = 'bg-green-500 shadow-[0_0_3px_#22c55e]';
+              }
+              return <div key={i} className={`w-2 h-0.5 rounded-[0.5px] transition-all duration-75 ${barColor}`} />;
+            })}
+          </div>
+          <div className="mixer-fadercell mixer-fadercell--m">
+            <Fader label="MST" value={masterVolume} onChange={onMasterVolumeChange} color="#FFFFFF" height="h-[var(--mixer-master-fader-height)]" />
+          </div>
+        </div>
+        <div className="mixer-fadercell mixer-fadercell--b">
+          <Fader label="B" value={deckBVolume} onChange={onDeckBVolumeChange} color="#F2B8B5" height="h-[var(--mixer-fader-height)]" />
+        </div>
+      </div>
+
+      <div className="mixer-footer mixer-band mixer-band--xfade">
         {/* Crossfader Section - Enhanced visual design */}
-        <div className="mt-4 space-y-2 pt-2 border-t border-white/5 relative">
+        <div className="mixer-crossfader space-y-2 pt-2 border-t border-white/5 relative">
           <div className="flex justify-between gap-1 p-0.5 bg-black/30 rounded-lg mb-1">
             {['SMOOTH', 'CUT', 'DIP'].map(curve => (
               <button 
@@ -424,7 +420,7 @@ const Mixer: React.FC<MixerProps> = ({
           </div>
         </div>
 
-        <div className="mt-3 rounded-lg border border-white/5 bg-black/30 p-2">
+        <div className="mixer-autodj rounded-lg border border-white/5 bg-black/30 p-2">
           <div className="flex items-center justify-between gap-2">
             <div className="flex flex-col">
               <span className="text-[8px] font-black uppercase tracking-widest text-gray-400">Auto DJ</span>

--- a/raikomix-youtube-dj_1.0/index.html
+++ b/raikomix-youtube-dj_1.0/index.html
@@ -269,6 +269,9 @@
     }
 
     .central-stage {
+      /* Layout philosophy: keep the console as one hardware-like instrument panel.
+         The outer wrapper centers the fixed-proportion panel; the inner grid aligns
+         deck + mixer tops/bottoms so nothing stretches when extra space appears. */
       --mixer-width: 224px;
       --deck-min: 360px;
       --central-gap: 20px;
@@ -276,13 +279,25 @@
       --central-padding-inline: 18px;
       --mixer-gap: 10px;
       --mixer-fader-height: 190px;
+      --mixer-master-fader-height: calc(var(--mixer-fader-height) - 24px);
       --mixer-meter-height: 110px;
       --central-stage-scale: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      min-height: 0;
+    }
+
+    .central-stage__panel {
+      /* Scaling strategy: apply a single scale to the panel at tight heights
+         so controls stay fixed-size and never stretch. */
       display: grid;
       grid-template-columns: minmax(var(--deck-min), 1fr) var(--mixer-width) minmax(var(--deck-min), 1fr);
       align-items: stretch;
       gap: var(--central-gap);
-      height: 100%;
+      height: auto;
+      max-height: 100%;
       min-height: 0;
       padding: var(--central-padding-block) var(--central-padding-inline);
       transform: scale(var(--central-stage-scale));
@@ -291,6 +306,11 @@
 
     .perform-stage__inner > *,
     .central-stage > * {
+      min-width: 0;
+      min-height: 0;
+    }
+
+    .central-stage__panel > * {
       min-width: 0;
       min-height: 0;
     }
@@ -330,9 +350,9 @@
       padding: 14px;
     }
 
-    .deck-card {
-      align-self: flex-start;
-      height: auto;
+    .central-stage .deck-card {
+      align-self: stretch;
+      height: 100%;
     }
 
     .mixer-card {
@@ -348,10 +368,11 @@
       align-self: stretch;
       min-width: 0;
       display: grid;
-      grid-template-rows: auto auto auto;
-      align-content: center;
+      grid-template-rows: auto auto auto auto;
+      align-content: start;
       row-gap: var(--mixer-gap);
       min-height: 0;
+      overflow: visible;
     }
 
     .mixer-header {
@@ -360,15 +381,37 @@
 
     .mixer-content {
       min-height: 0;
-      display: grid;
-      grid-template-rows: auto var(--mixer-fader-height);
-      align-content: center;
-      justify-items: stretch;
-      gap: var(--mixer-gap);
     }
 
     .mixer-footer {
       min-height: 0;
+    }
+
+    .mixer-band {
+      min-height: 0;
+      display: block;
+    }
+
+    .mixer-band--eq {
+      display: block;
+    }
+
+    .mixer-band--faders {
+      /* Stability note: fixed band heights (meter + fader) stop growth at large sizes,
+         while the grid keeps channel proportions locked across devices/zoom levels. */
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      align-items: end;
+      justify-items: center;
+      gap: 12px;
+    }
+
+    .mixer-masterstrip {
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
     }
 
     .mixer-upper {
@@ -428,6 +471,19 @@
       justify-content: center;
     }
 
+    .mixer-center-spine {
+      min-width: 40px;
+      width: 40px;
+    }
+
+    .mixer-crossfader {
+      margin-top: 8px;
+    }
+
+    .mixer-autodj {
+      margin-top: 10px;
+    }
+
     .mixer-fadercell--a,
     .mixer-fadercell--b {
       background: rgba(0, 0, 0, 0.1);
@@ -479,12 +535,12 @@
         gap: 6px;
       }
 
-      .central-stage .mixer-footer .mt-4 {
-        margin-top: 10px;
+      .central-stage .mixer-crossfader {
+        margin-top: 6px;
         padding-top: 6px;
       }
 
-      .central-stage .mixer-footer .mt-3 {
+      .central-stage .mixer-autodj {
         margin-top: 8px;
       }
     }
@@ -538,7 +594,7 @@
         overflow-y: auto;
       }
 
-      .central-stage {
+      .central-stage__panel {
         grid-template-columns: minmax(0, 1fr);
         grid-auto-rows: auto;
       }
@@ -585,12 +641,12 @@
         gap: 6px;
       }
 
-      .central-stage .mixer-footer .mt-4 {
-        margin-top: 10px;
+      .central-stage .mixer-crossfader {
+        margin-top: 6px;
         padding-top: 6px;
       }
 
-      .central-stage .mixer-footer .mt-3 {
+      .central-stage .mixer-autodj {
         margin-top: 8px;
       }
     }


### PR DESCRIPTION
### Motivation
- Create a single, hardware-like “center stage” where Deck A, Mixer, and Deck B behave as one instrument with shared top/bottom alignment and fixed visual proportions. 
- Ensure all existing controls remain present and never clip, hide, or introduce internal mixer scrollbars across laptop and external monitors, zoom levels, and short heights. 
- Keep logic and visual style unchanged while improving layout stability and predictability.

### Description
- Wrapped the three-stage area in a dedicated panel by adding a `central-stage__panel` wrapper and updated `App.tsx` so the decks and mixer are children of a single grid container. 
- Reorganized `components/Mixer.tsx` DOM into explicit bands: an EQ/filter band, a fader/meter band, and a crossfader/AutoDJ band while preserving every existing control and behavior. 
- Updated layout CSS in `index.html`: converted the outer `central-stage` to a centered flex container and moved the grid into `central-stage__panel`, added variables (`--mixer-master-fader-height`, fixed band heights), and added explanatory comments describing the scaling strategy and stability rules. 
- Kept all JavaScript logic and event handlers intact (changes are markup/CSS-first); added small accessibility/ARIA hints and structural spine element to visually separate channels without removing controls.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite reported as ready, which succeeded. 
- Ran an automated Playwright script that loaded `http://127.0.0.1:4173/` and captured a full-page screenshot saved as `artifacts/central-console.png`, which completed successfully. 
- Committed the changes with `git` after validation; no unit tests were present or modified for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f5eb1de088326b8f1ced8a70eed31)