### PR TITLE
Central console: centered hardware-like panel & fixed-band mixer CSS

### DIFF
--- a/raikomix-youtube-dj_1.0/index.html
+++ b/raikomix-youtube-dj_1.0/index.html
@@ -258,26 +258,30 @@
     }
 
     .perform-stage {
+      /* Panel centering strategy: stage owns the available space and keeps the
+         entire instrument panel centered without stretching the controls. */
       height: 100%;
       display: flex;
       justify-content: center;
       align-items: center;
       min-height: 0;
       overflow: hidden;
+      padding: 12px;
       container-type: size;
       container-name: central-stage;
     }
 
     .central-stage {
-      /* Layout philosophy: keep the console as one hardware-like instrument panel.
-         The outer wrapper centers the fixed-proportion panel; the inner grid aligns
-         deck + mixer tops/bottoms so nothing stretches when extra space appears. */
+      /* Hardware-like panel sizing tokens + fixed mixer bands. */
       --mixer-width: 224px;
-      --deck-min: 360px;
+      --deck-width: 420px;
       --central-gap: 20px;
       --central-padding-block: 16px;
       --central-padding-inline: 18px;
       --mixer-gap: 10px;
+      --mixer-eq-band-height: 260px;
+      --mixer-fader-band-height: 260px;
+      --mixer-xfade-band-height: 190px;
       --mixer-fader-height: 190px;
       --mixer-master-fader-height: calc(var(--mixer-fader-height) - 24px);
       --mixer-meter-height: 110px;
@@ -287,18 +291,19 @@
       justify-content: center;
       height: 100%;
       min-height: 0;
+      width: 100%;
     }
 
     .central-stage__panel {
-      /* Scaling strategy: apply a single scale to the panel at tight heights
-         so controls stay fixed-size and never stretch. */
+      /* Scaling strategy: one global knob (transform scale) applied to the panel only. */
       display: grid;
-      grid-template-columns: minmax(var(--deck-min), 1fr) var(--mixer-width) minmax(var(--deck-min), 1fr);
+      grid-template-columns: var(--deck-width) var(--mixer-width) var(--deck-width);
       align-items: stretch;
       gap: var(--central-gap);
       height: auto;
-      max-height: 100%;
       min-height: 0;
+      width: max-content;
+      max-width: 100%;
       padding: var(--central-padding-block) var(--central-padding-inline);
       transform: scale(var(--central-stage-scale));
       transform-origin: center;
@@ -325,14 +330,14 @@
     }
 
     .central-stage__deck > * {
-      height: 100%;
       min-height: 0;
       width: 100%;
     }
 
     .central-stage__mixer {
-      height: 100%;
       min-height: 0;
+      display: flex;
+      align-items: stretch;
     }
 
     .deck-title-stack {
@@ -362,13 +367,18 @@
       flex-direction: column;
     }
 
+    /* Fixed-band mixer strategy: explicit band heights lock meters/faders/xfader,
+       keeping the mixer stable across screens and zoom levels. */
     .mixer-shell {
       width: var(--mixer-width);
-      height: 100%;
       align-self: stretch;
       min-width: 0;
       display: grid;
-      grid-template-rows: auto auto auto auto;
+      grid-template-rows:
+        auto
+        var(--mixer-eq-band-height)
+        var(--mixer-fader-band-height)
+        var(--mixer-xfade-band-height);
       align-content: start;
       row-gap: var(--mixer-gap);
       min-height: 0;
@@ -387,13 +397,22 @@
       min-height: 0;
     }
 
+    .mixer-band--xfade {
+      height: var(--mixer-xfade-band-height);
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+    }
+
     .mixer-band {
       min-height: 0;
-      display: block;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start;
     }
 
     .mixer-band--eq {
-      display: block;
+      height: var(--mixer-eq-band-height);
     }
 
     .mixer-band--faders {
@@ -404,6 +423,7 @@
       align-items: end;
       justify-items: center;
       gap: 12px;
+      height: var(--mixer-fader-band-height);
     }
 
     .mixer-masterstrip {
@@ -507,11 +527,10 @@
       height: 5rem;
     }
 
-    /* Central Stage density modes:
-       - Comfort (default): generous gaps/padding.
-       - Compact: triggered by height thresholds to tighten spacing.
-       Safe scale: if height is still tight, scale down the central stage wrapper only. */
-    @container central-stage (max-height: 820px) {
+    /* Central Stage density + scale strategy:
+       - tighten spacing at smaller heights
+       - apply one global scale factor when space is tight */
+    @container central-stage (max-height: 860px) {
       .central-stage {
         --central-gap: 14px;
         --central-padding-block: 12px;
@@ -519,6 +538,9 @@
         --mixer-gap: 8px;
         --mixer-fader-height: 170px;
         --mixer-meter-height: 96px;
+        --mixer-eq-band-height: 240px;
+        --mixer-fader-band-height: 240px;
+        --mixer-xfade-band-height: 175px;
       }
 
       .central-stage .mixer-card,
@@ -545,9 +567,21 @@
       }
     }
 
+    @container central-stage (max-height: 780px) {
+      .central-stage {
+        --central-stage-scale: 0.96;
+      }
+    }
+
     @container central-stage (max-height: 720px) {
       .central-stage {
-        --central-stage-scale: 0.94;
+        --central-stage-scale: 0.92;
+      }
+    }
+
+    @container central-stage (max-height: 660px) {
+      .central-stage {
+        --central-stage-scale: 0.88;
       }
     }
 
@@ -585,15 +619,19 @@
     @media (max-width: 1280px) {
       .central-stage {
         --mixer-width: 210px;
-        --deck-min: 320px;
+        --deck-width: 360px;
+      }
+    }
+
+    @media (max-width: 1200px) {
+      .central-stage {
+        --mixer-width: 200px;
+        --deck-width: 320px;
+        --central-gap: 16px;
       }
     }
 
     @media (max-width: 1024px) {
-      .perform-stage {
-        overflow-y: auto;
-      }
-
       .central-stage__panel {
         grid-template-columns: minmax(0, 1fr);
         grid-auto-rows: auto;
@@ -617,7 +655,7 @@
       }
     }
 
-    @media (max-height: 820px) {
+    @media (max-height: 860px) {
       .central-stage {
         --central-gap: 14px;
         --central-padding-block: 12px;
@@ -625,6 +663,9 @@
         --mixer-gap: 8px;
         --mixer-fader-height: 170px;
         --mixer-meter-height: 96px;
+        --mixer-eq-band-height: 240px;
+        --mixer-fader-band-height: 240px;
+        --mixer-xfade-band-height: 175px;
       }
 
       .central-stage .mixer-card,
@@ -651,9 +692,21 @@
       }
     }
 
+    @media (max-height: 780px) {
+      .central-stage {
+        --central-stage-scale: 0.96;
+      }
+    }
+
     @media (max-height: 720px) {
       .central-stage {
-        --central-stage-scale: 0.94;
+        --central-stage-scale: 0.92;
+      }
+    }
+
+    @media (max-height: 660px) {
+      .central-stage {
+        --central-stage-scale: 0.88;
       }
     }
   </style>


### PR DESCRIPTION
### Motivation

- Create a hardware-like, centered “instrument panel” for Deck A + Mixer + Deck B that always shows all controls without stretching or internal scrollbars.  
- Prevent mixer/fader/meters from growing on large screens and stop decks from sinking to the bottom of the stage.  
- Provide a single global scale knob for the whole panel so the UI uniformly scales down when vertical space is constrained.

### Description

- Implemented a panel-centering strategy and global scaling tokens by updating layout CSS in `index.html`, introducing `--deck-width`, `--mixer-width`, `--central-stage-scale`, and related spacing tokens.  
- Converted the central console wrapper to a fixed grid (`.central-stage__panel`) with explicit columns for Deck A / Mixer / Deck B and set `width: max-content` so extra viewport space does not stretch controls.  
- Added a fixed-band mixer strategy by locking mixer band heights and changing `.mixer-shell` to explicit `grid-template-rows` for EQ / Meter+Faders / Crossfader bands, and added `.mixer-band--xfade`, `.mixer-band--faders`, and `.mixer-band--eq` heights to keep meters and faders stable.  
- Added container queries and a small set of height breakpoints that modify a single `--central-stage-scale` token (global scale) and tightened spacing at smaller heights, while avoiding many per-control clamp() rules; no JS or audio logic, handlers, or component props were changed.

### Testing

- Launched the dev server with `npm run dev` and observed Vite report `ready`, confirming the app served successfully.  
- Loaded the app and captured a full-page screenshot using Playwright which produced `artifacts/central-console.png`, validating the centered panel and fixed-band appearance.  
- No unit tests were modified or added, and no tests failed during the automated validation steps above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f6342e9f483269d6a57b2c6833df5)