### PR TITLE
Hot cues & loops: leveled layout, right-click clear, and Clear All

### DIFF
--- a/raikomix-youtube-dj_1.0/components/Deck.tsx
+++ b/raikomix-youtube-dj_1.0/components/Deck.tsx
@@ -422,6 +422,10 @@ const effectNodesRef = useRef<{
     }
   }, [state.hotCues, state.currentTime, state.sourceType]);
 
+  const handleClearAllHotCues = useCallback(() => {
+    setState(s => ({ ...s, hotCues: [null, null, null, null] }));
+  }, []);
+
   const togglePlay = useCallback(() => {
     // Resume context if suspended (browser policy)
     if (audioCtxRef.current?.state === 'suspended') {
@@ -790,30 +794,48 @@ const effectNodesRef = useRef<{
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3 mt-2">
-        <div className="bg-black/20 p-2 rounded-xl border border-white/5 space-y-2">
-          <div className="flex flex-col items-start gap-1 px-1">
-             <div className="text-[9px] text-gray-500 font-black uppercase tracking-widest">Hot Cues</div>
-             <div className="text-[7px] text-gray-700 font-black uppercase">Shift + Click to Clear</div>
+      <div className="grid grid-cols-2 gap-3 mt-2 items-stretch">
+        <div className="bg-black/20 p-2 rounded-xl border border-white/5 space-y-2 flex flex-col justify-between">
+          <div className="flex items-center justify-between px-1">
+            <div className="text-[9px] text-gray-500 font-black uppercase tracking-widest">Hot Cues</div>
+            <button
+              type="button"
+              onClick={handleClearAllHotCues}
+              className="h-5 px-2 rounded-md text-[8px] font-black uppercase tracking-widest border border-white/5 text-gray-500 hover:text-white hover:border-white/20 transition-all"
+            >
+              Clear All
+            </button>
           </div>
           <div className="grid grid-cols-4 gap-1">
             {[0, 1, 2, 3].map((i) => (
               <button 
                 key={i} 
-                onClick={(e) => handleHotCue(i, e.shiftKey)} 
+                onClick={() => handleHotCue(i)}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  handleHotCue(i, true);
+                }}
+                title={`Hot Cue ${i + 1} (Right-click to clear)`}
+                aria-label={`Hot Cue ${i + 1}`}
                 className={`h-8 rounded-lg font-black text-[10px] border transition-all ${state.hotCues[i] !== null ? 'text-black' : 'border-white/5 text-gray-700 hover:border-white/20'}`} 
                 style={state.hotCues[i] !== null ? { backgroundColor: CUE_COLORS[i], borderColor: CUE_COLORS[i], boxShadow: `0 0 10px ${CUE_COLORS[i]}44` } : {}}
               >
-                {i + 1}
+                <span className="sr-only">{`Hot Cue ${i + 1}`}</span>
               </button>
             ))}
           </div>
         </div>
-        <div className="bg-black/20 p-2 rounded-xl border border-white/5 space-y-2">
+        <div className="bg-black/20 p-2 rounded-xl border border-white/5 space-y-2 flex flex-col justify-between">
           <div className="text-[9px] text-gray-500 font-black uppercase tracking-widest px-1">Loops</div>
           <div className="grid grid-cols-4 gap-1">
             {[2, 4, 8, 16].map((b) => (
-              <button key={b} onClick={() => handleToggleLoop(b)} className={`h-7 rounded-lg text-[10px] font-black border transition-all ${state.loopActive && Math.abs((state.loopEnd - state.loopStart) - b * (60 / state.bpm)) < 0.1 ? 'bg-green-500 text-black border-green-500 shadow-[0_0_10px_rgba(34,197,94,0.4)]' : 'border-white/5 text-gray-500 hover:text-white hover:border-white/20'}`}>{b}</button>
+              <button
+                key={b}
+                onClick={() => handleToggleLoop(b)}
+                className={`h-8 rounded-lg text-[10px] font-black border transition-all ${state.loopActive && Math.abs((state.loopEnd - state.loopStart) - b * (60 / state.bpm)) < 0.1 ? 'bg-green-500 text-black border-green-500 shadow-[0_0_10px_rgba(34,197,94,0.4)]' : 'border-white/5 text-gray-500 hover:text-white hover:border-white/20'}`}
+              >
+                {b}
+              </button>
             ))}
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Make Hot Cues and Loops visually symmetrical and easier to use across decks by leveling their layout and spacing.
- Replace the modifier-based clear action with an explicit and discoverable mechanism to clear individual or all hot cues.
- Remove persistent numeric labels from cue pads and provide the explanation via hover/tooltips to declutter the UI.

### Description
- Added a new `handleClearAllHotCues` `useCallback` to reset all hot cues to `[null, null, null, null]` in `components/Deck.tsx`.
- Replaced the previous `Shift+Click` clear behavior by handling `onContextMenu` on each hot cue button to clear individual cues via right-click and added a `title` tooltip for hover explanation.
- Added a visible `Clear All` button in the Hot Cues header that calls `handleClearAllHotCues` and removed visible numeric labels on each pad in favor of an `sr-only` span for accessibility.
- Adjusted layout classes (added `items-stretch`, `flex flex-col justify-between`, and unified button heights to `h-8`) so Hot Cues and Loops panels are leveled and symmetrical.

### Testing
- Started the dev server with `npm run dev` and verified Vite served the app (server started successfully).
- Captured an automated UI screenshot using a Playwright script which completed and produced `artifacts/hot-cues-loops-layout.png` to validate layout changes (succeeded).
- No unit tests were changed and no additional automated unit test suites were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69810539788c83268289b4f4bdc165f0)