### PR TITLE
Auto DJ: select active deck by remaining time

### DIFF
--- a/raikomix-youtube-dj_1.0/App.tsx
+++ b/raikomix-youtube-dj_1.0/App.tsx
@@ -674,11 +674,28 @@ const App: React.FC = () => {
   }, [midiAccess, midiInputs]);
 
   const getActiveDeck = useCallback(() => {
-    if (deckAState?.playing && !deckBState?.playing) return 'A';
-    if (deckBState?.playing && !deckAState?.playing) return 'B';
-    if (deckAState?.playing && deckBState?.playing) return crossfader >= 0 ? 'B' : 'A';
+    const aPlaying = deckAState?.playing;
+    const bPlaying = deckBState?.playing;
+
+    if (aPlaying && !bPlaying) return 'A';
+    if (bPlaying && !aPlaying) return 'B';
+
+    if (aPlaying && bPlaying) {
+      const aRemaining = (deckAState?.duration || 0) - (deckAState?.currentTime || 0);
+      const bRemaining = (deckBState?.duration || 0) - (deckBState?.currentTime || 0);
+
+      return aRemaining <= bRemaining ? 'A' : 'B';
+    }
+
     return null;
-  }, [deckAState?.playing, deckBState?.playing, crossfader]);
+  }, [
+    deckAState?.playing,
+    deckAState?.duration,
+    deckAState?.currentTime,
+    deckBState?.playing,
+    deckBState?.duration,
+    deckBState?.currentTime,
+  ]);
 
   const handleDeckStateUpdate = useCallback((id: DeckId, state: PlayerState) => {
     id === 'A' ? setDeckAState(state) : setDeckBState(state);


### PR DESCRIPTION
### Motivation
- The Auto DJ currently chooses the active deck using the `crossfader` value when both decks are playing, which can pick the wrong deck during simultaneous playback. 
- The intent is for Auto DJ to target the deck that ends sooner so the next track is loaded and the mix lead timing is correct.

### Description
- Replaced the `getActiveDeck` implementation in `App.tsx` to compute active deck based on remaining time instead of `crossfader` when both decks are playing. 
- The new logic computes `aRemaining` and `bRemaining` as `(duration - currentTime)` and returns `'A'` when `aRemaining <= bRemaining` else `'B'`. 
- Updated the `useCallback` dependencies to include `deckAState?.duration`, `deckAState?.currentTime`, `deckBState?.duration`, and `deckBState?.currentTime` so the callback updates when timing state changes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69810d337e2083269c6c88805e464ea2)