### PR TITLE
Move mixer meter to center spine and tighten deck spacing

### DIFF
--- a/raikomix-youtube-dj_1.0/components/Mixer.tsx
+++ b/raikomix-youtube-dj_1.0/components/Mixer.tsx
@@ -296,7 +296,23 @@ const Mixer: React.FC<MixerProps> = ({
             </button>
           </div>
 
-          <div className="mixer-center-spine bg-black/30 rounded-xl border border-white/5 mx-0.5" aria-hidden="true" />
+          <div
+            className="mixer-center-spine bg-black/30 rounded-xl border border-white/5 mx-0.5 flex flex-col items-center justify-center py-2"
+            aria-hidden="false"
+          >
+            <div className="mixer-meter flex flex-col gap-0.5 items-center">
+              {[...Array(20)].reverse().map((_, i) => {
+                const isActive = (deckAPlaying || deckBPlaying) && (Math.random() > (i / 20));
+                let barColor = 'bg-green-900/10';
+                if (isActive) {
+                  if (i > 16) barColor = 'bg-red-500 shadow-[0_0_6px_red]';
+                  else if (i > 12) barColor = 'bg-orange-500 shadow-[0_0_4px_orange]';
+                  else barColor = 'bg-green-500 shadow-[0_0_3px_#22c55e]';
+                }
+                return <div key={i} className={`w-2 h-0.5 rounded-[0.5px] transition-all duration-75 ${barColor}`} />;
+              })}
+            </div>
+          </div>
 
           {/* Channel B Section */}
           <div className="mixer-channel bg-black/10 p-1.5 rounded-xl border border-white/5 w-full min-w-0 flex flex-col items-center gap-2">
@@ -326,18 +342,6 @@ const Mixer: React.FC<MixerProps> = ({
           <Fader label="A" value={deckAVolume} onChange={onDeckAVolumeChange} color="#D0BCFF" height="h-[var(--mixer-fader-height)]" />
         </div>
         <div className="mixer-masterstrip">
-          <div className="mixer-meter flex flex-col gap-0.5 items-center py-1">
-            {[...Array(20)].reverse().map((_, i) => {
-              const isActive = (deckAPlaying || deckBPlaying) && (Math.random() > (i / 20));
-              let barColor = 'bg-green-900/10';
-              if (isActive) {
-                if (i > 16) barColor = 'bg-red-500 shadow-[0_0_6px_red]';
-                else if (i > 12) barColor = 'bg-orange-500 shadow-[0_0_4px_orange]';
-                else barColor = 'bg-green-500 shadow-[0_0_3px_#22c55e]';
-              }
-              return <div key={i} className={`w-2 h-0.5 rounded-[0.5px] transition-all duration-75 ${barColor}`} />;
-            })}
-          </div>
           <div className="mixer-fadercell mixer-fadercell--m">
             <Fader label="MST" value={masterVolume} onChange={onMasterVolumeChange} color="#FFFFFF" height="h-[var(--mixer-master-fader-height)]" />
           </div>

--- a/raikomix-youtube-dj_1.0/index.html
+++ b/raikomix-youtube-dj_1.0/index.html
@@ -474,6 +474,7 @@
     .mixer-center-spine {
       min-width: 40px;
       width: 40px;
+      min-height: 200px;
     }
 
     .mixer-crossfader {
@@ -500,7 +501,8 @@
     }
 
     .deck-card {
-      gap: 12px;
+      gap: 10px;
+      padding-bottom: 8px;
     }
 
     .waveform-display {
@@ -521,9 +523,13 @@
         --mixer-meter-height: 96px;
       }
 
-      .central-stage .mixer-card,
-      .central-stage .deck-card {
+      .central-stage .mixer-card {
         padding: 12px;
+      }
+
+      .central-stage .deck-card {
+        padding: 12px 12px 6px;
+        gap: 8px;
       }
 
       .central-stage .mixer-topgrid {
@@ -627,9 +633,13 @@
         --mixer-meter-height: 96px;
       }
 
-      .central-stage .mixer-card,
-      .central-stage .deck-card {
+      .central-stage .mixer-card {
         padding: 12px;
+      }
+
+      .central-stage .deck-card {
+        padding: 12px 12px 6px;
+        gap: 8px;
       }
 
       .central-stage .mixer-topgrid {


### PR DESCRIPTION
### Motivation
- Center the vertical mixer level meters in the dark center spine between the EQ knobs for better visual alignment and to avoid the cluttered master strip area.
- Reduce deck/card spacing to produce a tighter, more compact central stage layout without overlapping elements.

### Description
- Moved the meter JSX from the master strip into the center spine in `components/Mixer.tsx` and wrapped it with `flex`/centering classes, keeping the vertical orientation and existing color/active logic.
- Removed the meter block from `.mixer-masterstrip` so the meter was moved (not copied) and the master fader remains the only element in the master strip.
- Updated `index.html` CSS to add `min-height: 200px` to `.mixer-center-spine` so the meters sit centered in the dark spine, reduced `.deck-card` `gap` to `10px` and added `padding-bottom: 8px`, and adjusted ` .central-stage .deck-card` padding/gap in the container queries to `padding: 12px 12px 6px` and `gap: 8px` for denser layout.
- Kept existing meter behavior (randomized active state for demo) and accessibility attributes updated (`aria-hidden` changed on the spine element).

### Testing
- Performed a visual smoke test by serving the site and taking a screenshot with Playwright; the screenshot run completed successfully and an artifact was produced (`artifacts/mixer-center-spine.png`).
- Verified repository status and committed the changes using `git` successfully.
- No unit tests, linters, or CI job runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69810fc5c9c08326a0ddd3e186680419)