### PR TITLE
Auto DJ: start next track early and trigger crossfade only at lead time

### DIFF
--- a/raikomix-youtube-dj_1.0/App.tsx
+++ b/raikomix-youtube-dj_1.0/App.tsx
@@ -106,9 +106,9 @@ const App: React.FC = () => {
   const pendingMixRef = useRef<{ deck: DeckId; fromDeck: DeckId; item: QueueItem } | null>(null);
   const lastAutoDeckRef = useRef<DeckId>('B');
   const autoLoadDeckRef = useRef<DeckId | null>(null);
-  const nextTrackPlayingRef = useRef<{ deck: DeckId; videoId: string } | null>(null);
   const lastMixVideoRef = useRef<{ A?: string | null; B?: string | null }>({});
   const preloadedTrackRef = useRef<{ deck: DeckId; itemId: string; videoId: string } | null>(null);
+  const earlyStartedTrackRef = useRef<{ deck: DeckId; videoId: string } | null>(null);
   const manualPauseRef = useRef<{ A: boolean; B: boolean }>({ A: false, B: false });
   const prevPlayingRef = useRef<{ A: boolean; B: boolean }>({ A: false, B: false });
   const autoStopRef = useRef<{ A: boolean; B: boolean }>({ A: false, B: false });
@@ -929,7 +929,7 @@ const App: React.FC = () => {
       const remaining = activeState.duration - activeState.currentTime;
       const leadTime = Math.min(Math.max(1, mixLeadSeconds), activeState.duration);
       const preloadTime = Math.min(activeState.duration, Math.max(leadTime + 6, leadTime * 2));
-      const playStartTime = Math.min(activeState.duration, leadTime + Math.max(2, mixDurationSeconds));
+      const playStartTime = leadTime + Math.max(2, mixDurationSeconds);
       const targetDeck = activeDeck === 'A' ? 'B' : 'A';
       const targetState = targetDeck === 'A' ? deckAState : deckBState;
       if (remaining <= preloadTime && queue.length > 0 && !targetState?.playing && !pendingMixRef.current) {
@@ -937,39 +937,50 @@ const App: React.FC = () => {
       }
 
       // Start next track playing BEFORE crossfade begins
-      if (remaining <= playStartTime && remaining > leadTime && !targetState?.playing) {
-        const alreadyStarted = nextTrackPlayingRef.current;
+      if (remaining <= playStartTime && remaining > leadTime && queue.length > 0 && !targetState?.playing && !pendingMixRef.current) {
+        const alreadyStarted = earlyStartedTrackRef.current;
+        const preloaded = preloadedTrackRef.current;
+        const queuedItem = queue[0];
 
         // Only start once per track
-        if (!alreadyStarted || alreadyStarted.deck !== targetDeck) {
-          const preloaded = preloadedTrackRef.current;
-          const queuedItem = queue[0];
+        if (alreadyStarted?.deck === targetDeck && alreadyStarted?.videoId === activeState.videoId) {
+          // Already started this track
+        } else if (preloaded && queuedItem && preloaded.itemId === queuedItem.id && preloaded.deck === targetDeck) {
+          // Preloaded track ready - start playing it NOW
+          console.log(`Auto DJ: Starting ${targetDeck} early at ${remaining.toFixed(1)}s remaining`);
 
-          if (preloaded && queuedItem && preloaded.itemId === queuedItem.id && preloaded.deck === targetDeck) {
-            // Preloaded track ready - start playing it
-            setQueue(prev => prev.filter(item => item.id !== queuedItem.id));
-            preloadedTrackRef.current = null;
-            nextTrackPlayingRef.current = { deck: targetDeck, videoId: queuedItem.videoId };
+          // Remove from queue
+          setQueue(prev => prev.filter(item => item.id !== queuedItem.id));
 
-            const targetRef = targetDeck === 'A' ? deckARef : deckBRef;
-            setTimeout(() => targetRef.current?.togglePlay(), 100);
-          }
+          // Mark as started
+          earlyStartedTrackRef.current = { deck: targetDeck, videoId: activeState.videoId };
+
+          // Clear preload ref
+          preloadedTrackRef.current = null;
+
+          // Start playing
+          const targetRef = targetDeck === 'A' ? deckARef : deckBRef;
+          setTimeout(() => {
+            targetRef.current?.togglePlay();
+          }, 150);
         }
       }
       if (remaining <= leadTime) {
         lastMixVideoRef.current[activeDeck] = activeState.videoId;
 
-        // If target deck is already playing, just crossfade
-        if (targetState?.playing) {
-          startAutoMix(activeDeck, targetDeck);
-        } else {
-          // Target not playing yet - queue for when ready
-          queueAutoMix(activeDeck);
-        }
+        // Check if we already started the target deck early
+        const startedEarly = earlyStartedTrackRef.current?.deck === targetDeck;
 
-        // Clear the playing ref after crossfade starts
-        if (nextTrackPlayingRef.current?.deck === targetDeck) {
-          nextTrackPlayingRef.current = null;
+        if (targetState?.playing || startedEarly) {
+          // Target deck is already playing - just start crossfade
+          console.log(`Auto DJ: Starting crossfade at ${remaining.toFixed(1)}s remaining`);
+          startAutoMix(activeDeck, targetDeck);
+
+          // Clear early start ref
+          earlyStartedTrackRef.current = null;
+        } else {
+          // Target deck not playing - use pendingMix flow
+          queueAutoMix(activeDeck);
         }
       }
     }, 250);
@@ -986,7 +997,7 @@ const App: React.FC = () => {
     manualPauseRef.current = { A: false, B: false };
     prevPlayingRef.current = { A: false, B: false };
     autoStopRef.current = { A: false, B: false };
-    nextTrackPlayingRef.current = null;
+    earlyStartedTrackRef.current = null;
   }, [autoDjEnabled]);
 
   useEffect(() => {
@@ -1000,26 +1011,21 @@ const App: React.FC = () => {
   useEffect(() => {
     if (!pendingMix) return;
     const targetState = pendingMix.deck === 'A' ? deckAState : deckBState;
+    const targetRef = pendingMix.deck === 'A' ? deckARef : deckBRef;
 
     if (!targetState?.isReady) return;
 
-    // If target deck is playing, start crossfade immediately
-    if (targetState.playing) {
-      startAutoMix(pendingMix.fromDeck, pendingMix.deck);
-      pendingMixRef.current = null;
-      setPendingMix(null);
-    } else {
-      // Target not ready to play yet - wait for it
-      const targetRef = pendingMix.deck === 'A' ? deckARef : deckBRef;
-      targetRef.current?.togglePlay();
+    console.log(`Auto DJ: pendingMix executing for deck ${pendingMix.deck}, isPlaying=${targetState.playing}`);
 
-      // Crossfade will start when track begins playing
-      setTimeout(() => {
-        startAutoMix(pendingMix.fromDeck, pendingMix.deck);
-        pendingMixRef.current = null;
-        setPendingMix(null);
-      }, 500);
+    // Start playing if not already
+    if (!targetState.playing) {
+      targetRef.current?.togglePlay();
     }
+
+    // Start crossfade immediately (this is emergency fallback or instant mix mode)
+    startAutoMix(pendingMix.fromDeck, pendingMix.deck);
+    pendingMixRef.current = null;
+    setPendingMix(null);
   }, [pendingMix, deckAState, deckBState, startAutoMix]);
 
 useEffect(() => {


### PR DESCRIPTION
### Motivation
- Auto DJ was starting the pending mix logic at `leadTime`, which caused the next track start and crossfade to interfere and produce incorrect early/late timing.
- The goal is to start the next track earlier (so both decks play during the overlap) and only trigger the crossfade at `leadTime` to ensure smooth transitions.

### Description
- Added `earlyStartedTrackRef` to track tracks that were started early and replaced the previous `nextTrackPlayingRef` usage with this new ref by adding `const earlyStartedTrackRef = useRef<{ deck: DeckId; videoId: string } | null>(null)`.
- Cleared `earlyStartedTrackRef` when Auto DJ is disabled by setting `earlyStartedTrackRef.current = null` in the existing cleanup `useEffect` for `autoDjEnabled`.
- Changed the timing calculation to compute `playStartTime` as `leadTime + Math.max(2, mixDurationSeconds)` so the next track is started earlier than the crossfade, and added logic to start the preloaded track at `playStartTime` (remove from queue, clear `preloadedTrackRef`, set `earlyStartedTrackRef`, and `togglePlay` the target deck) only if not already started.
- Modified the `leadTime` branch to check `earlyStartedTrackRef` and, if the target deck is already playing or was started early, call `startAutoMix` immediately and clear the early-start ref; otherwise fall back to the existing `queueAutoMix` pending flow.
- Simplified the `pendingMix` `useEffect` to log execution, ensure the target deck is playing by calling `togglePlay()` if needed, and then immediately call `startAutoMix` as an emergency/instant fallback.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981153737988326887bae98e8ee2e66)