### PR TITLE
Fix Auto DJ useEffect dependencies (handleLoadVideo, startAutoMix)

### DIFF
--- a/raikomix-youtube-dj_1.0/App.tsx
+++ b/raikomix-youtube-dj_1.0/App.tsx
@@ -1016,7 +1016,7 @@ const App: React.FC = () => {
       }
     }, 250);
     return () => clearInterval(interval);
-  }, [autoDjEnabled, queue, deckAState, deckBState, mixLeadSeconds, mixDurationSeconds, getActiveDeck, loadNextQueueItem, triggerDeckPlay, queueAutoMix, preloadNextQueueItem]);
+  }, [autoDjEnabled, queue, deckAState, deckBState, mixLeadSeconds, mixDurationSeconds, getActiveDeck, loadNextQueueItem, triggerDeckPlay, queueAutoMix, preloadNextQueueItem, handleLoadVideo, startAutoMix]);
 
   useEffect(() => {
     if (autoDjEnabled) return;


### PR DESCRIPTION
### Motivation
- Prevent a stale-closure bug in the Auto DJ early-start logic where `handleLoadVideo` and `startAutoMix` were called but not included in the `useEffect` dependency array, causing those functions to be out-of-date.

### Description
- Add `handleLoadVideo` and `startAutoMix` to the dependency array of the Auto DJ `useEffect` in `raikomix-youtube-dj_1.0/App.tsx` so the effect captures the latest function references.

### Testing
- No automated tests were run after this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69811a75c8088326b985c2dc9c8977f5)