### PR TITLE
Fix Auto DJ cue readiness for existing players

### DIFF
--- a/raikomix-youtube-dj_1.0/components/Deck.tsx
+++ b/raikomix-youtube-dj_1.0/components/Deck.tsx
@@ -448,10 +448,11 @@ const effectNodesRef = useRef<{
     if (playerRef.current) {
       try {
         // Reset state for existing player to avoid GUI freeze/glitch
+        // IMPORTANT: Keep isReady=true for cue mode so Auto DJ can trigger playback
         setState(s => ({ 
           ...s, 
           videoId, 
-          isReady: false, 
+          isReady: loadMode === 'cue' ? true : false,  // Keep ready for cued tracks
           sourceType: 'youtube',
           playbackRate: 1.0,
           playing: false,
@@ -464,7 +465,7 @@ const effectNodesRef = useRef<{
         } else {
           playerRef.current.loadVideoById(videoId);
         }
-        setIsLoading(true);
+        setIsLoading(loadMode !== 'cue');  // Don't show loader for cue
       } catch (e) { 
         setIsLoading(false); 
       }


### PR DESCRIPTION
### Motivation
- Cued YouTube tracks were being marked `isReady=false` which prevented Auto DJ from starting playback when a track was cued.
- `cueVideoById` preloads the video in a paused state and should allow playback to be triggered without forcing a loading state.

### Description
- Changed `initPlayer` to keep `isReady` true when `loadMode === 'cue'` by setting `isReady: loadMode === 'cue' ? true : false` in the state update.
- Prevented the global loader from showing for cue operations by calling `setIsLoading(loadMode !== 'cue')` instead of always setting loading to `true`.
- Added a clarifying comment explaining that cued tracks must remain ready so Auto DJ can trigger playback.

### Testing
- No automated tests were run against the modified code.
- The change is limited to `raikomix-youtube-dj_1.0/components/Deck.tsx` and compiles as a small state/logic tweak (manual runtime verification recommended).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69811bef7e108326a3d3c53d3f140bce)