### PR TITLE
Fix recording guard for local tab in PerformancePadDialog

### DIFF
--- a/raikomix-youtube-dj_1.0/components/PerformancePadDialog.tsx
+++ b/raikomix-youtube-dj_1.0/components/PerformancePadDialog.tsx
@@ -376,7 +376,7 @@ const PerformancePadDialog: React.FC<PerformancePadDialogProps> = ({
 
   useEffect(() => {
     if (activeTab !== 'local' && isRecording) {
-      stopRecording();
+      void stopRecording();
     }
   }, [activeTab, isRecording, stopRecording]);
 
@@ -842,6 +842,7 @@ const PerformancePadDialog: React.FC<PerformancePadDialogProps> = ({
                       <button
                         type="button"
                         onClick={isRecording ? stopRecording : startRecording}
+                        disabled={activeTab !== 'local'}
                         className={`px-4 py-2 rounded-full text-[10px] font-black uppercase tracking-widest transition ${
                           isRecording
                             ? 'bg-[#F2B8B5] text-black shadow-[0_0_18px_rgba(242,184,181,0.5)]'


### PR DESCRIPTION
### Motivation
- Prevent recording lifecycle conflicts when switching tabs by ensuring recording only runs on the `local` tab and making the stop call async-safe.

### Description
- Replace `stopRecording()` with `void stopRecording()` inside the `useEffect` that watches `activeTab` so the stop call is invoked without blocking effects.
- Disable the record button by adding `disabled={activeTab !== 'local'}` so users cannot start/stop recordings while on non-local tabs.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready (Local/Network URLs), indicating the app served successfully. 
- Attempted an automated UI check with Playwright to capture a dialog screenshot, but the headless browser crashed so the E2E check failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69811f4afa848326bbf9fc87518fafe5)