### PR TITLE
Fix local track IDs and cue playback readiness

### DIFF
--- a/raikomix-youtube-dj_1.0/App.tsx
+++ b/raikomix-youtube-dj_1.0/App.tsx
@@ -950,6 +950,14 @@ const App: React.FC = () => {
           // CASE 1: Preloaded track ready - start playing it NOW
           console.log(`[Auto DJ] Starting ${targetDeck} early (preloaded) at ${remaining.toFixed(1)}s remaining`);
 
+          if (queuedItem.sourceType === 'local') {
+            const expectedVideoId = `local_${queuedItem.url}`;
+            if (!targetState?.isReady || targetState.videoId !== expectedVideoId) {
+              console.warn(`[Auto DJ] Local file not ready on ${targetDeck}, skipping early start`);
+              return;
+            }
+          }
+
           // Remove from queue
           setQueue(prev => prev.filter(item => item.id !== queuedItem.id));
 

--- a/raikomix-youtube-dj_1.0/components/Deck.tsx
+++ b/raikomix-youtube-dj_1.0/components/Deck.tsx
@@ -547,7 +547,9 @@ const effectNodesRef = useRef<{
         }));
 
         
-        analyzeLocalAudio(url);
+        if (loadMode !== 'cue') {
+          analyzeLocalAudio(url);
+        }
         
         onPlayerReady({
           setVolume: (v: number) => { if(localAudioRef.current) localAudioRef.current.volume = v / 100; },

--- a/raikomix-youtube-dj_1.0/components/LibraryPanel.tsx
+++ b/raikomix-youtube-dj_1.0/components/LibraryPanel.tsx
@@ -249,10 +249,11 @@ const LibraryPanel: React.FC<LibraryPanelProps> = ({
           }
         }
 
+        const url = URL.createObjectURL(file);
         return {
           id: `local_${Date.now()}_${Math.random().toString(36).substr(2, 5)}`,
-          videoId: `local_${file.name}_${Date.now()}`,
-          url: URL.createObjectURL(file),
+          videoId: `local_${url}`,
+          url,
           title,
           author,
           album,
@@ -298,10 +299,11 @@ const LibraryPanel: React.FC<LibraryPanelProps> = ({
           }
         }
 
+        const url = URL.createObjectURL(file);
         return {
           id: `local_${Date.now()}_${Math.random().toString(36).substr(2, 5)}`,
-          videoId: `local_${file.name}_${Date.now()}`,
-          url: URL.createObjectURL(file),
+          videoId: `local_${url}`,
+          url,
           title,
           author,
           album,


### PR DESCRIPTION
### Motivation
- Resolve inconsistent `videoId` for local files that caused preloaded items to not match the deck-loaded item and broke Auto DJ early-start logic.
- Avoid expensive/irrelevant audio analysis when a local file is merely being cued so cue-mode remains lightweight and responsive.
- Prevent Auto DJ from triggering early playback for local preloads until the deck actually reports the expected local source.

### Description
- Library import now generates stable IDs using the object URL so local tracks use `videoId: \`local_${url}\`` when adding single files or folders in `components/LibraryPanel.tsx`.
- Deck local load behavior in `components/Deck.tsx` was adjusted to skip `analyzeLocalAudio(url)` when `loadMode === 'cue'` to keep cueing lightweight and avoid unnecessary CPU work.
- Auto DJ early-start flow in `App.tsx` now guards preloaded local items by checking `queuedItem.sourceType === 'local'` and verifying the target deck is ready and its `videoId` equals `local_${queuedItem.url}` before performing the early start.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981216ca1c08326b20b82cd3c11923f)