### PR TITLE
Fix Auto DJ early-start readiness and tracking

### DIFF
--- a/raikomix-youtube-dj_1.0/types.ts
+++ b/raikomix-youtube-dj_1.0/types.ts
@@ -46,6 +46,10 @@ export interface PlayerState {
   videoId: string;
   sourceType: TrackSourceType;
   isReady: boolean;
+  bpm: number;
+  musicalKey: string;
+  title: string;
+  author: string;
   eqHigh: number;
   eqMid: number;
   eqLow: number;


### PR DESCRIPTION
### Motivation
- Prevent Auto DJ from attempting to early-start a queued track before the target deck is actually ready and avoid mis-identifying which track was started early.
- Make local file loading more robust so `loadedmetadata` reliably flips `isReady` and doesn't leak event handlers.
- Keep `PlayerState` type in sync with fields that `Deck.tsx` actually stores to reduce accidental mismatches.

### Description
- Change early-start bookkeeping in `App.tsx` to track the queued item identity by updating `earlyStartedTrackRef` to `{ deck, itemId, activeVideoId }` and compare `itemId` (and `activeVideoId`) when deciding "already started" or when starting crossfades. 
- Gate early-start behaviour on deck readiness by requiring `targetState?.isReady === true` before removing the queued item and calling `togglePlay()`, and in the failsafe path load before starting if the deck isn't ready. 
- Harden local-file readiness in `components/Deck.tsx` by adding `loadModeRef` and `localMetadataListenerRef`, registering a single `loadedmetadata` listener with `{ once: true }` before setting `src`/calling `load()`, and adding `preload="auto"` to the `<audio>` element, and using `loadModeRef` to control post-load analysis. 
- Update `types.ts` to include `bpm`, `musicalKey`, `title`, and `author` in `PlayerState` so the type matches the actual deck state fields.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69812d95a3e48326b234dd3d045b73d5)