### PR TITLE
Fix crossfader dead-zone by aligning handle and pointer math

### DIFF
--- a/raikomix-youtube-dj_1.0/components/Mixer.tsx
+++ b/raikomix-youtube-dj_1.0/components/Mixer.tsx
@@ -324,10 +324,9 @@ const Mixer: React.FC<MixerProps> = ({
     const rect = crossfaderRef.current?.getBoundingClientRect();
     if (!rect) return;
     const rootFont = parseFloat(getComputedStyle(document.documentElement).fontSize || '16');
-    const padding = rootFont;
     const handleWidth = rootFont * 5;
-    const usable = Math.max(1, rect.width - padding * 2 - handleWidth);
-    const x = Math.min(Math.max(clientX - rect.left - padding - handleWidth / 2, 0), usable);
+    const usable = Math.max(1, rect.width - handleWidth);
+    const x = Math.min(Math.max(clientX - rect.left - handleWidth / 2, 0), usable);
     const t = x / usable;
     const newVal = t * 2 - 1;
     onCrossfaderChange(newVal);
@@ -452,7 +451,7 @@ const Mixer: React.FC<MixerProps> = ({
           {/* Redesigned Professional Crossfader with tactile feel */}
           <div 
             ref={crossfaderRef}
-                className="bg-black/80 h-14 rounded-xl relative group flex items-center px-4 border border-white/10 shadow-[inset_0_4px_12px_rgba(0,0,0,0.8)] cursor-pointer overflow-hidden transition-all hover:border-white/20 touch-none"
+            className="bg-black/80 h-14 rounded-xl relative group flex items-center border border-white/10 shadow-[inset_0_4px_12px_rgba(0,0,0,0.8)] cursor-pointer overflow-hidden transition-all hover:border-white/20 touch-none"
             onDoubleClick={() => onCrossfaderChange(0)}
             title="Scroll to Mix • Double-click to Center (50/0)"
           >
@@ -460,15 +459,15 @@ const Mixer: React.FC<MixerProps> = ({
              <div className="absolute left-1/2 -translate-x-1/2 w-[2px] h-6 bg-white/10 z-0 rounded-full" />
              
              {/* Visual track guides */}
-             <div className="absolute inset-x-8 h-[1px] bg-white/5 top-1/2 -translate-y-1/2 pointer-events-none" />
-             <div className="absolute left-10 w-[1px] h-3 bg-white/5 pointer-events-none" />
-             <div className="absolute right-10 w-[1px] h-3 bg-white/5 pointer-events-none" />
+             <div className="absolute inset-x-4 h-[1px] bg-white/5 top-1/2 -translate-y-1/2 pointer-events-none" />
+             <div className="absolute left-4 w-[1px] h-3 bg-white/5 pointer-events-none" />
+             <div className="absolute right-4 w-[1px] h-3 bg-white/5 pointer-events-none" />
 
              {/* Professional Aluminum-style Crossfader Handle */}
              <div 
                className="absolute top-1/2 -translate-y-1/2 w-20 h-11 bg-[#323038] rounded-md border border-white/20 shadow-[0_12px_24px_rgba(0,0,0,0.7),inset_0_1px_1px_rgba(255,255,255,0.1)] flex items-center justify-center transition-all duration-150 z-10 group-hover:border-[#D0BCFF]/40 active:scale-95 active:shadow-inner"
                style={{ 
-                 left: `calc(1rem + ${(crossfader + 1) / 2} * (100% - 2rem - 5rem))`,
+                 left: `calc(${(crossfader + 1) / 2} * (100% - 5rem))`,
                }}
              >
                {/* Tactile Handle Ridges */}


### PR DESCRIPTION
### Motivation
- The crossfader handle and pointer-to-value math double-counted side padding, which shortened the usable travel and prevented the handle from reaching the track edges.
- Visual guide offsets (inset-x-8 / left-10 / right-10) and the track `px-4` padding stayed mismatched with the handle travel, causing visible gaps at full left/right.

### Description
- Updated pointer conversion in `Mixer.tsx` to compute usable travel as `rect.width - handleWidth` and removed the extra side padding from the pointer origin calculation so drag/click maps to full travel.
- Removed the track container `px-4` class so the handle can visually reach the edges and adjusted the guide markers from `inset-x-8 / left-10 / right-10` to `inset-x-4 / left-4 / right-4` for alignment.
- Changed the handle CSS `left` calculation to `calc(${(crossfader + 1) / 2} * (100% - 5rem))` so the handle spans from 0% to `100% - handleWidth`.
- All code changes are in `raikomix-youtube-dj_1.0/components/Mixer.tsx` and replace the previous padding-aware math.

### Testing
- Ran `npm run build` which completed successfully and produced the production build without errors.
- Launched the dev server (`npm run dev`) and executed an automated Playwright script that loaded the page and captured a screenshot to validate the visual handle placement (screenshot artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948fddaf488326acaf4331f93363f2)