### PR TITLE
Fix paused seek playhead visibility and confirm seek state

### DIFF
--- a/raikomix-youtube-dj_1.0/components/Waveform.tsx
+++ b/raikomix-youtube-dj_1.0/components/Waveform.tsx
@@ -175,11 +175,11 @@ const Waveform: React.FC<WaveformProps> = ({
     }
 
     ctx.save();
-    ctx.globalAlpha = mode === 'soft' ? 0.45 : 0.6;
-    ctx.shadowBlur = mode === 'soft' ? 10 : 8;
+    ctx.globalAlpha = mode === 'soft' ? 0.65 : 0.6;
+    ctx.shadowBlur = mode === 'soft' ? 14 : 8;
     ctx.shadowColor = color;
     ctx.strokeStyle = color;
-    ctx.lineWidth = mode === 'soft' ? 1.4 : 1.2;
+    ctx.lineWidth = mode === 'soft' ? 2 : 1.2;
     ctx.beginPath();
     ctx.moveTo(x, height * 0.12);
     ctx.lineTo(x, height * 0.88);
@@ -540,7 +540,7 @@ const Waveform: React.FC<WaveformProps> = ({
     }
 
     const p = duration > 0 ? currentTime / duration : 0;
-    drawPlayhead(ctx, width, height, p, 'soft');
+    drawPlayhead(ctx, width, height, p, 'strong');
 
     if (!runningRef.current) return;
     requestRef.current = requestAnimationFrame(draw);


### PR DESCRIPTION
### Motivation
- Seeking while a deck is paused left the playhead visually unstable because the polling useEffect bails when not playing, and the idle sine-wave fallback rendered the playhead too faint to see.
- The change ensures a user-visible, accurate playhead immediately after seek even when the regular polling loop is inactive.

### Description
- Added a one-shot 150ms readback in `seekToTime` (Deck.tsx) to confirm and update `currentTime` after an optimistic seek when the deck is paused, with defensive error logging for YouTube readback failures.
- Switched the fallback idle visualization playhead render mode from `soft` to `strong` in `Waveform.tsx` so the playhead remains visible without waveform data.
- Increased the visual contrast for the `soft` playhead by boosting alpha, shadow blur, and stroke width in `Waveform.tsx` so it is readable on dark/animated backgrounds.

### Testing
- Ran `npm run build` (Vite production build) which completed successfully.
- Ran `npm test` (Vitest) with all test files and tests passing (2 test files, 49 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699494e5a6388326b24d97704bdb8d16)